### PR TITLE
Add endpoint for root password rotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gophercloud/gophercloud v0.23.0
 	github.com/gophercloud/utils v0.0.0-20210909165623-d7085207ff6d
 	github.com/hashicorp/go-hclog v1.0.0
+	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/vault/api v1.3.0
 	github.com/hashicorp/vault/sdk v0.3.0
 	github.com/stretchr/testify v1.7.0
@@ -32,7 +33,6 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.1 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
-	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/go-version v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -42,6 +42,7 @@ func Factory(_ context.Context, _ *logical.BackendConfig) (logical.Backend, erro
 			b.pathClouds(),
 			b.pathRole(),
 			b.pathRoles(),
+			b.pathRotateRoot(),
 		},
 		BackendType: logical.TypeLogical,
 	}
@@ -60,6 +61,7 @@ func (b *backend) getSharedCloud(name string) *sharedCloud {
 	return cloud
 }
 
+// getClient returns initialized Keystone service client
 func (c *sharedCloud) getClient(ctx context.Context, s logical.Storage) (*gophercloud.ServiceClient, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/openstack/fixtures/helpers.go
+++ b/openstack/fixtures/helpers.go
@@ -1,6 +1,14 @@
 package fixtures
 
-import "reflect"
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+)
 
 // isEmpty gets whether the specified object is considered empty or not.
 func isEmpty(object interface{}) bool {
@@ -39,4 +47,88 @@ func SanitizedMap(in map[string]interface{}) map[string]interface{} {
 		}
 	}
 	return out
+}
+
+func handleCreateToken(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+
+	th.TestHeader(t, r, "Content-Type", "application/json")
+	th.TestHeader(t, r, "Accept", "application/json")
+
+	w.WriteHeader(http.StatusCreated)
+	_, _ = fmt.Fprintf(w, `
+{
+  "token": {
+    "expires_at": "2014-10-02T13:45:00.000000Z",
+    "catalog": [
+      {
+        "endpoints": [
+          {
+            "id": "id",
+            "interface": "public",
+            "region": "RegionOne",
+            "region_id": "RegionOne",
+            "url": "%s"
+          }
+        ],
+        "id": "idk",
+        "name": "keystone",
+        "type": "identity"
+      }
+    ]
+  }
+}
+`, client.ServiceClient().Endpoint)
+}
+
+func handleGetToken(t *testing.T, w http.ResponseWriter, r *http.Request, userID string) {
+	t.Helper()
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, `
+{
+  "token": {
+    "user": {
+      "id": "%s"
+    }
+  }
+}
+`, userID)
+}
+
+type EnabledMocks struct {
+	TokenPost      bool
+	TokenGet       bool
+	PasswordChange bool
+}
+
+func SetupKeystoneMock(t *testing.T, userID string, enabled EnabledMocks) {
+	t.Helper()
+
+	th.SetupHTTP()
+	t.Cleanup(th.TeardownHTTP)
+
+	th.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "POST":
+			if enabled.TokenPost {
+				handleCreateToken(t, w, r)
+			}
+		case "GET":
+			if enabled.TokenGet {
+				handleGetToken(t, w, r, userID)
+			}
+		default:
+			w.WriteHeader(404)
+		}
+	})
+
+	if enabled.PasswordChange {
+		th.Mux.HandleFunc(fmt.Sprintf("/v3/users/%s/password", userID), func(w http.ResponseWriter, r *http.Request) {
+			th.TestHeader(t, r, "Content-Type", "application/json")
+			th.TestHeader(t, r, "Accept", "application/json")
+
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
 }

--- a/openstack/path_rotate_root.go
+++ b/openstack/path_rotate_root.go
@@ -1,0 +1,109 @@
+package openstack
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	pwdDefaultSet = `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@#$%^&*()_+-={}[]:"'<>,./|\'?`
+
+	rotateHelpSyn  = "Rotate root cloud password."
+	rotateHelpDesc = `
+Rotate the cloud's root user credentials.
+
+Once this method is called, Vault will now be the only entity that knows the password used to access OpenStack instance.
+`
+)
+
+var (
+	pathRotateRoot = fmt.Sprintf("rotate-root/%s", framework.GenericNameRegex("cloud"))
+)
+
+func (b *backend) pathRotateRoot() *framework.Path {
+	return &framework.Path{
+		Pattern: pathRotateRoot,
+		Fields: map[string]*framework.FieldSchema{
+			"cloud": {
+				Type:        framework.TypeString,
+				Required:    true,
+				Description: "Specifies name of the cloud which credentials will be rotated.",
+			},
+			"size": {
+				Type:        framework.TypeInt,
+				Description: "Specifies the new password length.",
+				Default:     16,
+			},
+			"charset": {
+				Type:        framework.TypeString,
+				Description: "Specifies the new password character set.",
+				Default:     pwdDefaultSet,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.rotateRootCredentials,
+			},
+		},
+		HelpSynopsis:    rotateHelpSyn,
+		HelpDescription: rotateHelpDesc,
+	}
+}
+
+func randomPassword(charset string, size int) string {
+	var bytes = make([]byte, size)
+	_, _ = rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = charset[b%byte(len(charset))]
+	}
+	return string(bytes)
+}
+
+func (b *backend) rotateRootCredentials(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	cloudName := d.Get("cloud").(string)
+
+	sharedCloud := b.getSharedCloud(cloudName)
+	client, err := sharedCloud.getClient(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	user, err := tokens.Get(client, client.Token()).ExtractUser()
+	if err != nil {
+		return nil, err
+	}
+
+	cloudConfig, err := sharedCloud.getCloudConfig(ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	newPassword := randomPassword(
+		d.Get("charset").(string),
+		d.Get("size").(int),
+	)
+
+	// make sure we don't use this cloud until the password is changed
+	sharedCloud.lock.Lock()
+	defer sharedCloud.lock.Unlock()
+
+	err = users.ChangePassword(client, user.ID, users.ChangePasswordOpts{
+		Password:         newPassword,
+		OriginalPassword: cloudConfig.Password,
+	}).ExtractErr()
+	if err != nil {
+		return nil, err
+	}
+	cloudConfig.Password = newPassword
+
+	if err := cloudConfig.save(ctx, req.Storage); err != nil {
+		return nil, err
+	}
+
+	return &logical.Response{}, nil
+}

--- a/openstack/path_rotate_root_test.go
+++ b/openstack/path_rotate_root_test.go
@@ -1,0 +1,106 @@
+package openstack
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	thClient "github.com/gophercloud/gophercloud/testhelper/client"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack/fixtures"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRotateRootCredentials_ok(t *testing.T) {
+	userID, _ := uuid.GenerateUUID()
+	fixtures.SetupKeystoneMock(t, userID, fixtures.EnabledMocks{TokenPost: true, TokenGet: true, PasswordChange: true})
+
+	b, s := testBackend(t)
+
+	cloud := &sharedCloud{name: tools.RandomString("cl", 5)}
+
+	testClient := thClient.ServiceClient()
+	authURL := testClient.Endpoint + "v3"
+
+	entry, err := logical.StorageEntryJSON(storageCloudKey(cloud.name), OsCloud{
+		Name:           cloud.name,
+		AuthURL:        authURL,
+		Username:       tools.RandomString("u", 5) + "r",
+		Password:       tools.MakeNewPassword(""),
+		UserDomainName: tools.RandomString("d", 5),
+	})
+	require.NoError(t, err)
+	require.NoError(t, s.Put(context.Background(), entry))
+
+	_, err = b.HandleRequest(context.Background(), &logical.Request{
+		Path:      "rotate-root/" + cloud.name,
+		Operation: logical.ReadOperation,
+		Storage:   s,
+	})
+	require.NoError(t, err)
+}
+
+func TestRotateRootCredentials_error(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read-fail", func(t *testing.T) {
+		userID, _ := uuid.GenerateUUID()
+		fixtures.SetupKeystoneMock(t, userID, fixtures.EnabledMocks{})
+
+		b, s := testBackend(t, failVerbRead)
+
+		cloud := &sharedCloud{name: tools.RandomString("cl", 5)}
+
+		_, err := b.HandleRequest(context.Background(), &logical.Request{
+			Path:      "rotate-root/" + cloud.name,
+			Operation: logical.ReadOperation,
+			Storage:   s,
+		})
+		require.Error(t, err)
+	})
+
+	cases := map[string]fixtures.EnabledMocks{
+		"no-change": {
+			TokenPost: true, TokenGet: true,
+		},
+		"no-post": {
+			TokenGet: true, PasswordChange: true,
+		},
+		"no-get": {
+			TokenPost: true, PasswordChange: true,
+		},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := data
+			userID, _ := uuid.GenerateUUID()
+			fixtures.SetupKeystoneMock(t, userID, data)
+
+			b, s := testBackend(t)
+
+			cloud := &sharedCloud{name: tools.RandomString("cl", 5)}
+
+			testClient := thClient.ServiceClient()
+			authURL := testClient.Endpoint + "v3"
+
+			entry, err := logical.StorageEntryJSON(storageCloudKey(cloud.name), OsCloud{
+				Name:           cloud.name,
+				AuthURL:        authURL,
+				Username:       tools.RandomString("u", 5) + "r",
+				Password:       tools.MakeNewPassword(""),
+				UserDomainName: tools.RandomString("d", 5),
+			})
+			require.NoError(t, err)
+			require.NoError(t, s.Put(context.Background(), entry))
+
+			_, err = b.HandleRequest(context.Background(), &logical.Request{
+				Path:      "rotate-root/" + cloud.name,
+				Operation: logical.ReadOperation,
+				Storage:   s,
+			})
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Implement password rotation for the root user of the cloud.

Resolve #14 