### PR TITLE
Add methods for real cloud in acceptance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ BINARY_PATH =$(VAULT_PLUGIN_DIR)/$(PROJECT)
 # unset OS_ variables
 env_vars ::= $(shell env | grep -oE 'OS_[^=]+' )
 unexport $(env_vars)
+export OS_CLOUD OS_CLIENT_CONFIG_FILE
 
 module_path ::= github.com/opentelekomcloud/vault-plugin-secrets-openstack
 ldflags ::= -s -w \


### PR DESCRIPTION
Load cofiguration from `clouds.yaml` and use it later in acceptance tests

Example usage:
```go
func (p *PluginTest) TestPrepareCloud() {
	t := p.T()

	cloud := p.prepareCloud()
	require.NotEmpty(t, cloud)
	t.Log(cloud)
}
```