### PR TITLE
Module refactoring

### DIFF
--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -2,6 +2,7 @@ package openstack
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/gophercloud/gophercloud"
@@ -89,6 +90,9 @@ func (c *sharedCloud) initClient(ctx context.Context, s logical.Storage) error {
 	cloud, err := c.getCloudConfig(ctx, s)
 	if err != nil {
 		return err
+	}
+	if cloud == nil { // this happened at least once during acceptance test
+		return fmt.Errorf("no cloud found with name %s", c.name)
 	}
 
 	clientOpts := &clientconfig.ClientOpts{

--- a/openstack/path_creds.go
+++ b/openstack/path_creds.go
@@ -14,8 +14,6 @@ import (
 )
 
 const (
-	nameDefaultSet = `0123456789abcdefghijklmnopqrstuvwxyz`
-
 	pathCreds = "creds"
 
 	credsHelpSyn  = "Manage the OpenStack credentials with roles."
@@ -118,7 +116,7 @@ func getRootCredentials(client *gophercloud.ServiceClient, role *roleEntry, conf
 }
 
 func getTmpUserCredentials(client *gophercloud.ServiceClient, role *roleEntry, config *OsCloud) (*logical.Response, error) {
-	password := randomString(pwdDefaultSet, 6)
+	password := RandomString(PwdDefaultSet, 6)
 	user, err := createUser(client, password)
 	if err != nil {
 		return nil, err
@@ -267,7 +265,7 @@ func (b *backend) userDelete(ctx context.Context, r *logical.Request, d *framewo
 }
 
 func createUser(client *gophercloud.ServiceClient, password string) (*users.User, error) {
-	username := randomString(nameDefaultSet, 6)
+	username := RandomString(NameDefaultSet, 6)
 	createOpts := users.CreateOpts{
 		Name:        username,
 		Description: "Vault's temporary user",

--- a/openstack/path_rotate_root.go
+++ b/openstack/path_rotate_root.go
@@ -2,7 +2,6 @@ package openstack
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
@@ -12,8 +11,6 @@ import (
 )
 
 const (
-	pwdDefaultSet = `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@#$%^&*()_+-={}[]:"'<>,./|\'?`
-
 	rotateHelpSyn  = "Rotate root cloud password."
 	rotateHelpDesc = `
 Rotate the cloud's root user credentials.
@@ -43,7 +40,7 @@ func (b *backend) pathRotateRoot() *framework.Path {
 			"charset": {
 				Type:        framework.TypeString,
 				Description: "Specifies the new password character set.",
-				Default:     pwdDefaultSet,
+				Default:     PwdDefaultSet,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
@@ -54,15 +51,6 @@ func (b *backend) pathRotateRoot() *framework.Path {
 		HelpSynopsis:    rotateHelpSyn,
 		HelpDescription: rotateHelpDesc,
 	}
-}
-
-func randomString(charset string, size int) string {
-	var bytes = make([]byte, size)
-	_, _ = rand.Read(bytes)
-	for i, b := range bytes {
-		bytes[i] = charset[b%byte(len(charset))]
-	}
-	return string(bytes)
 }
 
 func (b *backend) rotateRootCredentials(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
@@ -83,7 +71,7 @@ func (b *backend) rotateRootCredentials(ctx context.Context, req *logical.Reques
 		return nil, err
 	}
 
-	newPassword := randomString(
+	newPassword := RandomString(
 		d.Get("charset").(string),
 		d.Get("size").(int),
 	)

--- a/openstack/random_string.go
+++ b/openstack/random_string.go
@@ -1,0 +1,17 @@
+package openstack
+
+import "crypto/rand"
+
+const (
+	NameDefaultSet = `0123456789abcdefghijklmnopqrstuvwxyz`
+	PwdDefaultSet  = `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@#$%^&*()_+-={}[]:"'<>,./|\'?`
+)
+
+func RandomString(charset string, size int) string {
+	var bytes = make([]byte, size)
+	_, _ = rand.Read(bytes)
+	for i, b := range bytes {
+		bytes[i] = charset[b%byte(len(charset))]
+	}
+	return string(bytes)
+}


### PR DESCRIPTION
Move common random generation methods to one file

Make random methods exported, so they can be used in acceptance

Cover panic raised in `initClient` during acceptance tests

Let's pretend it resolves #22