### PR TITLE
Add `user_roles` property in `role` path

### DIFF
--- a/acceptance/roles_test.go
+++ b/acceptance/roles_test.go
@@ -25,6 +25,7 @@ type roleData struct {
 	Root        bool                   `json:"root"`
 	SecretType  string                 `json:"secret_type"`
 	UserGroups  []interface{}          `json:"user_groups"`
+	UserRoles   []interface{}          `json:"user_roles"`
 }
 
 func extractRoleData(t *testing.T, resp *http.Response) *roleData {
@@ -43,7 +44,7 @@ func (p *PluginTest) TestRoleLifecycle() {
 
 	cloud := &openstack.OsCloud{
 		Name:           openstack.RandomString(openstack.NameDefaultSet, 10),
-		AuthURL:        "http://example.com/v3",
+		AuthURL:        "https://example.com/v3",
 		UserDomainName: openstack.RandomString(openstack.NameDefaultSet, 10),
 		Username:       openstack.RandomString(openstack.NameDefaultSet, 10),
 		Password:       openstack.RandomString(openstack.PwdDefaultSet, 10),
@@ -81,6 +82,7 @@ func (p *PluginTest) TestRoleLifecycle() {
 			Root:        data["root"].(bool),
 			SecretType:  data["secret_type"].(string),
 			UserGroups:  data["user_groups"].([]interface{}),
+			UserRoles:   data["user_roles"].([]interface{}),
 		}
 		assert.Equal(t, expected, extractRoleData(t, resp))
 	})
@@ -121,6 +123,7 @@ func expectedRoleData(cloudName string) map[string]interface{} {
 		"root":         false,
 		"secret_type":  "token",
 		"user_groups":  []interface{}{},
+		"user_roles":   []interface{}{},
 	}
 	return expectedMap
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -139,6 +139,7 @@ created. If the role exists, it will be updated with the new attributes.
 - `root` `(bool: <optional>)` - Specifies whenever to use the root user as a role actor.
   If set to `true`, `secret_type` can't be set to `password`.
   If set to `true`, `user_groups` value is ignored.
+  if set to `true`, `user_roles` value is ignored.
   If set to `true`, `ttl` value is ignored.
 
 - `ttl` `(string: "1h")` - Specifies TTL value for the dynamically created users as a
@@ -148,6 +149,9 @@ created. If the role exists, it will be updated with the new attributes.
   Valid choices are `token` and `password`.
 
 - `user_groups` `(list: []`) - Specifies list of existing OpenStack groups this Vault role is allowed to assume.
+  This is a comma-separated string or JSON array.
+
+- `user_roles` `(list: []`) - Specifies list of existing OpenStack roles this Vault role is allowed to assume.
   This is a comma-separated string or JSON array.
 
 - `project_id` `(string: <optional>)` - Create a project-scoped role with given project ID. Mutually exclusive with
@@ -185,6 +189,9 @@ $ curl \
   "user_groups": [
     "default",
     "testing"
+  ],
+  "user_roles": [
+    "member"
   ]
 }
 ```
@@ -209,6 +216,9 @@ $ curl \
   "user_groups": [
     "default",
     "testing"
+  ],
+  "user_roles": [
+    "member"
   ]
 }
 ```
@@ -222,6 +232,9 @@ $ curl \
   "user_groups": [
     "default",
     "testing"
+  ],
+  "user_roles": [
+    "member"
   ],
   "extensions": [
     "volume_api_version=3",
@@ -239,6 +252,9 @@ or
   "user_groups": [
     "default",
     "testing"
+  ],
+  "user_roles": [
+    "member"
   ],
   "extensions": {
     "volume_api_version": 3,
@@ -279,6 +295,9 @@ $ curl \
   "user_groups": [
     "default",
     "testing"
+  ],
+  "user_roles": [
+    "member"
   ],
   "ttl": "1h30m"
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -148,10 +148,10 @@ created. If the role exists, it will be updated with the new attributes.
 - `secret_type` `(string: "token")` - Specifies what kind of secret will configuration contain.
   Valid choices are `token` and `password`.
 
-- `user_groups` `(list: []`) - Specifies list of existing OpenStack groups this Vault role is allowed to assume.
+- `user_groups` `(list: [])` - Specifies list of existing OpenStack groups this Vault role is allowed to assume.
   This is a comma-separated string or JSON array.
 
-- `user_roles` `(list: []`) - Specifies list of existing OpenStack roles this Vault role is allowed to assume.
+- `user_roles` `(list: ["member"])` - Specifies list of existing OpenStack roles this Vault role is allowed to assume.
   This is a comma-separated string or JSON array.
 
 - `project_id` `(string: <optional>)` - Create a project-scoped role with given project ID. Mutually exclusive with
@@ -189,9 +189,6 @@ $ curl \
   "user_groups": [
     "default",
     "testing"
-  ],
-  "user_roles": [
-    "member"
   ]
 }
 ```
@@ -216,9 +213,6 @@ $ curl \
   "user_groups": [
     "default",
     "testing"
-  ],
-  "user_roles": [
-    "member"
   ]
 }
 ```
@@ -232,9 +226,6 @@ $ curl \
   "user_groups": [
     "default",
     "testing"
-  ],
-  "user_roles": [
-    "member"
   ],
   "extensions": [
     "volume_api_version=3",
@@ -252,9 +243,6 @@ or
   "user_groups": [
     "default",
     "testing"
-  ],
-  "user_roles": [
-    "member"
   ],
   "extensions": {
     "volume_api_version": 3,

--- a/openstack/path_role.go
+++ b/openstack/path_role.go
@@ -92,6 +92,7 @@ func (b *backend) pathRole() *framework.Path {
 			"user_roles": {
 				Type:        framework.TypeCommaStringSlice,
 				Description: "Specifies list of existing OpenStack roles this Vault role is allowed to assume.",
+				Default:     []string{"member"},
 			},
 			"project_id": {
 				Type:        framework.TypeLowerCaseString,

--- a/openstack/path_role.go
+++ b/openstack/path_role.go
@@ -91,7 +91,7 @@ func (b *backend) pathRole() *framework.Path {
 			},
 			"user_roles": {
 				Type:        framework.TypeCommaStringSlice,
-				Description: "Specifies list of existing OpenStack Identity roles this Vault role is allowed to assume.",
+				Description: "Specifies list of existing OpenStack roles this Vault role is allowed to assume.",
 			},
 			"project_id": {
 				Type:        framework.TypeLowerCaseString,

--- a/openstack/path_role_test.go
+++ b/openstack/path_role_test.go
@@ -47,6 +47,7 @@ func expectedRoleData(cloudName string) (*roleEntry, map[string]interface{}) {
 		"root":         false,
 		"secret_type":  "token",
 		"user_groups":  []string{},
+		"user_roles":   []string{},
 	}
 	return expected, expectedMap
 }
@@ -315,7 +316,7 @@ func TestRoleCreate(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 
 		b, s := testBackend(t)
-		cloudName := precreateCloud(t, s)
+		cloudName := preCreateCloud(t, s)
 
 		cases := map[string]*roleEntry{
 			"admin": {
@@ -329,6 +330,7 @@ func TestRoleCreate(t *testing.T) {
 				ProjectName: randomRoleName(),
 				SecretType:  SecretToken,
 				UserGroups:  []string{"default", "testing"},
+				UserRoles:   []string{"member"},
 			},
 			"password": {
 				Name:        randomRoleName(),
@@ -336,6 +338,7 @@ func TestRoleCreate(t *testing.T) {
 				ProjectName: randomRoleName(),
 				SecretType:  SecretPassword,
 				UserGroups:  []string{"default", "testing"},
+				UserRoles:   []string{"member"},
 			},
 			"ttl": {
 				Name:        randomRoleName(),
@@ -343,6 +346,7 @@ func TestRoleCreate(t *testing.T) {
 				ProjectName: randomRoleName(),
 				SecretType:  SecretToken,
 				UserGroups:  []string{"default", "testing"},
+				UserRoles:   []string{"member"},
 				TTL:         24 * time.Hour,
 			},
 			"endpoint-override": {
@@ -392,7 +396,7 @@ func TestRoleCreate(t *testing.T) {
 		}
 
 		b, s := testBackend(t)
-		cloudName := precreateCloud(t, s)
+		cloudName := preCreateCloud(t, s)
 
 		notForRootRe := regexp.MustCompile(`impossible to set .+ for the root user`)
 		cases := map[string]*errRoleEntry{
@@ -417,6 +421,14 @@ func TestRoleCreate(t *testing.T) {
 					Cloud:      cloudName,
 					Root:       true,
 					UserGroups: []string{"ug-1"},
+				},
+				errorRegex: notForRootRe,
+			},
+			"root-user-roles": {
+				roleEntry: &roleEntry{
+					Cloud:     cloudName,
+					Root:      true,
+					UserRoles: []string{"ur-1"},
 				},
 				errorRegex: notForRootRe,
 			},
@@ -478,7 +490,7 @@ func TestRoleCreate(t *testing.T) {
 	})
 }
 
-func precreateCloud(t *testing.T, s logical.Storage) string {
+func preCreateCloud(t *testing.T, s logical.Storage) string {
 	t.Helper()
 
 	name := randomRoleName()
@@ -504,7 +516,7 @@ func TestRoleUpdate(t *testing.T) {
 	t.Parallel()
 
 	b, s := testBackend(t)
-	cloudName := precreateCloud(t, s)
+	cloudName := preCreateCloud(t, s)
 
 	t.Run("ok", func(t *testing.T) {
 		roleName := randomRoleName()

--- a/openstack/path_role_test.go
+++ b/openstack/path_role_test.go
@@ -330,7 +330,6 @@ func TestRoleCreate(t *testing.T) {
 				ProjectName: randomRoleName(),
 				SecretType:  SecretToken,
 				UserGroups:  []string{"default", "testing"},
-				UserRoles:   []string{"member"},
 			},
 			"password": {
 				Name:        randomRoleName(),
@@ -338,7 +337,6 @@ func TestRoleCreate(t *testing.T) {
 				ProjectName: randomRoleName(),
 				SecretType:  SecretPassword,
 				UserGroups:  []string{"default", "testing"},
-				UserRoles:   []string{"member"},
 			},
 			"ttl": {
 				Name:        randomRoleName(),
@@ -346,7 +344,6 @@ func TestRoleCreate(t *testing.T) {
 				ProjectName: randomRoleName(),
 				SecretType:  SecretToken,
 				UserGroups:  []string{"default", "testing"},
-				UserRoles:   []string{"member"},
 				TTL:         24 * time.Hour,
 			},
 			"endpoint-override": {


### PR DESCRIPTION
### Description
Add possibility to set `user_roles`
Resolves: #53 

### Acceptance tests
```
rgyrbu@vrnnb-prc480:/windir/c/Users/rodgyrbu/Documents/vault-plugin-secrets-openstack$ make functional
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
    roles_test.go:52: Cloud with name `2m2l1yir4l` was created
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== CONT  TestPlugin/TestRoleLifecycle
    plugin_test.go:307: Cloud with name `2m2l1yir4l` has been removed
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:50: Cloud with name `default1` was created
    rotate_test.go:53: Cloud with name `ouf4` was created
    plugin_test.go:307: Cloud with name `ouf4` has been removed
    plugin_test.go:307: Cloud with name `default1` has been removed
--- PASS: TestPlugin (4.44s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.51s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.50s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.02s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.01s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (3.28s)
PASS
ok      github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   4
```
