### PR TITLE
Restructure response of `creds` path

### DIFF
--- a/acceptance/creds_test.go
+++ b/acceptance/creds_test.go
@@ -5,6 +5,7 @@ package acceptance
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"testing"
 
@@ -29,6 +30,7 @@ func (p *PluginTest) TestCredsLifecycle() {
 		Root       bool
 		SecretType string
 		UserRoles  []string
+		Extensions map[string]interface{}
 	}
 
 	cases := map[string]testCase{
@@ -45,6 +47,9 @@ func (p *PluginTest) TestCredsLifecycle() {
 			Root:       false,
 			SecretType: "token",
 			UserRoles:  []string{"member"},
+			Extensions: map[string]interface{}{
+				"identity_api_version": "3",
+			},
 		},
 		"user_password": {
 			Cloud:      cloud.Name,
@@ -52,6 +57,9 @@ func (p *PluginTest) TestCredsLifecycle() {
 			DomainID:   aux.DomainID,
 			Root:       false,
 			SecretType: "password",
+			Extensions: map[string]interface{}{
+				"object_store_endpoint_override": "https://swift.example.com",
+			},
 		},
 	}
 
@@ -81,7 +89,7 @@ func (p *PluginTest) TestCredsLifecycle() {
 			resp, err = p.vaultDo(
 				http.MethodPost,
 				roleURL(roleName),
-				cloudToRoleMap(data.Root, data.Cloud, data.ProjectID, data.DomainID, data.SecretType, data.UserRoles),
+				cloudToRoleMap(data.Root, data.Cloud, data.ProjectID, data.DomainID, data.SecretType, data.UserRoles, data.Extensions),
 			)
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusNoContent, resp.StatusCode, readJSONResponse(t, resp))
@@ -100,7 +108,10 @@ func (p *PluginTest) TestCredsLifecycle() {
 				nil,
 			)
 			require.NoError(t, err)
-			assert.Equal(t, http.StatusOK, resp.StatusCode, readJSONResponse(t, resp))
+			raw := readJSONResponse(t, resp)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, raw)
+
+			log.Printf("CREDENTIALS RESPONSE: %+v", raw)
 
 			resp, err = p.vaultDo(
 				http.MethodDelete,
@@ -137,7 +148,7 @@ func cloudToCloudMap(cloud *openstack.OsCloud) map[string]interface{} {
 	}
 }
 
-func cloudToRoleMap(root bool, cloud, projectID, domainID, secretType string, userRoles []string) map[string]interface{} {
+func cloudToRoleMap(root bool, cloud, projectID, domainID, secretType string, userRoles []string, extensions map[string]interface{}) map[string]interface{} {
 	return fixtures.SanitizedMap(map[string]interface{}{
 		"cloud":       cloud,
 		"project_id":  projectID,
@@ -145,5 +156,6 @@ func cloudToRoleMap(root bool, cloud, projectID, domainID, secretType string, us
 		"root":        root,
 		"secret_type": secretType,
 		"user_roles":  userRoles,
+		"extensions":  extensions,
 	})
 }

--- a/acceptance/creds_test.go
+++ b/acceptance/creds_test.go
@@ -5,7 +5,6 @@ package acceptance
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"testing"
 
@@ -108,10 +107,7 @@ func (p *PluginTest) TestCredsLifecycle() {
 				nil,
 			)
 			require.NoError(t, err)
-			raw := readJSONResponse(t, resp)
-			assert.Equal(t, http.StatusOK, resp.StatusCode, raw)
-
-			log.Printf("CREDENTIALS RESPONSE: %+v", raw)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, readJSONResponse(t, resp))
 
 			resp, err = p.vaultDo(
 				http.MethodDelete,

--- a/openstack/path_creds.go
+++ b/openstack/path_creds.go
@@ -466,9 +466,7 @@ func getScopeFromRole(role *roleEntry) tokens.Scope {
 }
 
 func formAuthResponse(role *roleEntry, username, password, token, authURL, domainID string) map[string]interface{} {
-	auth := map[string]interface{}{
-		"auth_url": authURL,
-	}
+	var auth map[string]interface{}
 
 	switch {
 	case role.ProjectID != "":
@@ -493,6 +491,8 @@ func formAuthResponse(role *roleEntry, username, password, token, authURL, domai
 		auth["username"] = username
 		auth["password"] = password
 	}
+
+	auth["auth_url"] = authURL
 
 	return auth
 }

--- a/openstack/path_creds_test.go
+++ b/openstack/path_creds_test.go
@@ -120,7 +120,7 @@ func TestCredentialsRead_ok(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, res.IsError(), res.Error())
 		require.NotEmpty(t, res.Data)
-		require.NotEmpty(t, res.Data["password"])
+		require.NotEmpty(t, res.Data["auth"])
 		require.NotEmpty(t, res.Secret.InternalData["user_id"])
 
 		_, err = b.HandleRequest(context.Background(), &logical.Request{

--- a/openstack/path_creds_test.go
+++ b/openstack/path_creds_test.go
@@ -57,7 +57,7 @@ func TestCredentialsRead_ok(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, res.Data)
-		assert.NotEmpty(t, res.Data["expires_at"])
+		assert.NotEmpty(t, res.Data["auth"])
 	})
 	t.Run("user_token", func(t *testing.T) {
 		require.NoError(t, s.Put(context.Background(), cloudEntry))
@@ -97,7 +97,9 @@ func TestCredentialsRead_ok(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, res.Data)
-		require.Equal(t, res.Data["token"], testClient.TokenID)
+		require.NotEmpty(t, res.Data["auth"])
+		authInfo := res.Data["auth"].(map[string]interface{})
+		require.Equal(t, authInfo["token"], testClient.TokenID)
 
 		_, err = b.HandleRequest(context.Background(), &logical.Request{
 			Operation: logical.RevokeOperation,


### PR DESCRIPTION
## Description
Make response of `creds` path in `clouds.yaml` like style
Resolves: #78

## Acceptance tests
```
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
    roles_test.go:53: Cloud with name `9u8zkyv1eq` was created
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== CONT  TestPlugin/TestRoleLifecycle
    plugin_test.go:337: Cloud with name `9u8zkyv1eq` has been removed
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `5yai` was created
    plugin_test.go:337: Cloud with name `5yai` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
--- PASS: TestPlugin (11.26s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.44s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.43s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (4.77s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (2.52s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (0.79s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (0.58s)
    --- PASS: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.01s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (4.42s)
PASS
ok      github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   11.264s
```

## Unit tests
```
=== RUN   TestBackend_sharedCloud
--- PASS: TestBackend_sharedCloud (0.00s)
=== RUN   TestBackend_sharedCloud/existing
    --- PASS: TestBackend_sharedCloud/existing (0.00s)
=== RUN   TestBackend_sharedCloud/non-existing
    --- PASS: TestBackend_sharedCloud/non-existing (0.00s)
=== RUN   TestSharedCloud_client
--- PASS: TestSharedCloud_client (0.00s)
=== RUN   TestSharedCloud_client/existing-client
    --- PASS: TestSharedCloud_client/existing-client (0.00s)
=== RUN   TestSharedCloud_client/new-client
    --- PASS: TestSharedCloud_client/new-client (0.00s)
=== RUN   TestCloudCreate
--- PASS: TestCloudCreate (0.00s)
=== RUN   TestCloudCreate/EmptyConfig
    --- PASS: TestCloudCreate/EmptyConfig (0.00s)
=== RUN   TestCloudCreate/Create
    --- PASS: TestCloudCreate/Create (0.00s)
=== RUN   TestCloudCreate/Update
    --- PASS: TestCloudCreate/Update (0.00s)
=== RUN   TestCloudCreate/Read
    --- PASS: TestCloudCreate/Read (0.00s)
=== RUN   TestCloudCreate/Delete
    --- PASS: TestCloudCreate/Delete (0.00s)
=== RUN   TestCloudCreate/List
    --- PASS: TestCloudCreate/List (0.00s)
=== RUN   TestCredentialsRead_ok
--- PASS: TestCredentialsRead_ok (0.01s)
=== RUN   TestCredentialsRead_ok/root_token
    --- PASS: TestCredentialsRead_ok/root_token (0.00s)
=== RUN   TestCredentialsRead_ok/user_token
    --- PASS: TestCredentialsRead_ok/user_token (0.00s)
=== RUN   TestCredentialsRead_ok/user_password
    --- PASS: TestCredentialsRead_ok/user_password (0.00s)
=== RUN   TestCredentialsRead_ok/token_revoke
    --- PASS: TestCredentialsRead_ok/token_revoke (0.00s)
=== RUN   TestCredentialsRead_ok/user_password_revoke
    --- PASS: TestCredentialsRead_ok/user_password_revoke (0.00s)
=== RUN   TestCredentialsRead_error
--- PASS: TestCredentialsRead_error (0.00s)
=== RUN   TestCredentialsRead_error/read-fail
    --- PASS: TestCredentialsRead_error/read-fail (0.00s)
=== RUN   TestCredentialsRead_error/no-users-token-post
    --- PASS: TestCredentialsRead_error/no-users-token-post (0.00s)
=== RUN   TestCredentialsRead_error/no-user-post
    --- PASS: TestCredentialsRead_error/no-user-post (0.00s)
=== RUN   TestCredentialsRevoke_error
--- PASS: TestCredentialsRevoke_error (0.00s)
=== RUN   TestCredentialsRevoke_error/no-token-delete
    --- PASS: TestCredentialsRevoke_error/no-token-delete (0.00s)
=== RUN   TestCredentialsRevoke_error/no-user-delete
    --- PASS: TestCredentialsRevoke_error/no-user-delete (0.00s)
=== RUN   TestInfoRead
=== PAUSE TestInfoRead
=== CONT  TestInfoRead
--- PASS: TestInfoRead (0.00s)
=== RUN   TestRoleStoragePath
--- PASS: TestRoleStoragePath (0.00s)
=== RUN   TestRoleGet
=== PAUSE TestRoleGet
=== CONT  TestRoleGet
--- PASS: TestRoleGet (0.00s)
=== RUN   TestRoleGet/existing
=== PAUSE TestRoleGet/existing
=== CONT  TestRoleGet/existing
    --- PASS: TestRoleGet/existing (0.00s)
=== RUN   TestRoleGet/not-existing
=== PAUSE TestRoleGet/not-existing
=== CONT  TestRoleGet/not-existing
    --- PASS: TestRoleGet/not-existing (0.00s)
=== RUN   TestRoleGet/get-err
=== PAUSE TestRoleGet/get-err
=== CONT  TestRoleGet/get-err
    --- PASS: TestRoleGet/get-err (0.00s)
=== RUN   TestRoleExistence
=== PAUSE TestRoleExistence
=== CONT  TestRoleExistence
--- PASS: TestRoleExistence (0.00s)
=== RUN   TestRoleExistence/existing
=== PAUSE TestRoleExistence/existing
=== CONT  TestRoleExistence/existing
    --- PASS: TestRoleExistence/existing (0.00s)
=== RUN   TestRoleExistence/not-existing
=== PAUSE TestRoleExistence/not-existing
=== CONT  TestRoleExistence/not-existing
    --- PASS: TestRoleExistence/not-existing (0.00s)
=== RUN   TestRoleExistence/get-err
=== PAUSE TestRoleExistence/get-err
=== CONT  TestRoleExistence/get-err
    --- PASS: TestRoleExistence/get-err (0.00s)
=== RUN   TestRoleList
=== PAUSE TestRoleList
=== CONT  TestRoleList
--- PASS: TestRoleList (0.00s)
=== RUN   TestRoleList/ok
    --- PASS: TestRoleList/ok (0.00s)
=== RUN   TestRoleList/error
=== PAUSE TestRoleList/error
=== CONT  TestRoleList/error
    --- PASS: TestRoleList/error (0.00s)
=== RUN   TestRoleList/filter
=== PAUSE TestRoleList/filter
=== CONT  TestRoleList/filter
    --- PASS: TestRoleList/filter (0.00s)
=== RUN   TestRoleList/filter-get-err
=== PAUSE TestRoleList/filter-get-err
=== CONT  TestRoleList/filter-get-err
    --- PASS: TestRoleList/filter-get-err (0.00s)
=== RUN   TestRoleDelete
=== PAUSE TestRoleDelete
=== CONT  TestRoleDelete
--- PASS: TestRoleDelete (0.00s)
=== RUN   TestRoleDelete/existing
=== PAUSE TestRoleDelete/existing
=== CONT  TestRoleDelete/existing
    --- PASS: TestRoleDelete/existing (0.00s)
=== RUN   TestRoleDelete/not-existing
=== PAUSE TestRoleDelete/not-existing
=== CONT  TestRoleDelete/not-existing
    --- PASS: TestRoleDelete/not-existing (0.00s)
=== RUN   TestRoleDelete/error
=== PAUSE TestRoleDelete/error
=== CONT  TestRoleDelete/error
    --- PASS: TestRoleDelete/error (0.00s)
=== RUN   TestRoleDelete/error-get
=== PAUSE TestRoleDelete/error-get
=== CONT  TestRoleDelete/error-get
    --- PASS: TestRoleDelete/error-get (0.00s)
=== RUN   TestRoleCreate
=== PAUSE TestRoleCreate
=== CONT  TestRoleCreate
--- PASS: TestRoleCreate (0.01s)
=== RUN   TestRoleCreate/ok
    --- PASS: TestRoleCreate/ok (0.00s)
=== RUN   TestRoleCreate/ok/token
=== PAUSE TestRoleCreate/ok/token
=== CONT  TestRoleCreate/ok/token
        --- PASS: TestRoleCreate/ok/token (0.00s)
=== RUN   TestRoleCreate/ok/password
=== PAUSE TestRoleCreate/ok/password
=== CONT  TestRoleCreate/ok/password
        --- PASS: TestRoleCreate/ok/password (0.00s)
=== RUN   TestRoleCreate/ok/ttl
=== PAUSE TestRoleCreate/ok/ttl
=== CONT  TestRoleCreate/ok/ttl
        --- PASS: TestRoleCreate/ok/ttl (0.00s)
=== RUN   TestRoleCreate/ok/endpoint-override
=== PAUSE TestRoleCreate/ok/endpoint-override
=== CONT  TestRoleCreate/ok/endpoint-override
        --- PASS: TestRoleCreate/ok/endpoint-override (0.00s)
=== RUN   TestRoleCreate/ok/admin
=== PAUSE TestRoleCreate/ok/admin
=== CONT  TestRoleCreate/ok/admin
        --- PASS: TestRoleCreate/ok/admin (0.00s)
=== RUN   TestRoleCreate/error
    --- PASS: TestRoleCreate/error (0.00s)
=== RUN   TestRoleCreate/error/root-password
=== PAUSE TestRoleCreate/error/root-password
=== CONT  TestRoleCreate/error/root-password
        --- PASS: TestRoleCreate/error/root-password (0.00s)
=== RUN   TestRoleCreate/error/root-user-groups
=== PAUSE TestRoleCreate/error/root-user-groups
=== CONT  TestRoleCreate/error/root-user-groups
        --- PASS: TestRoleCreate/error/root-user-groups (0.00s)
=== RUN   TestRoleCreate/error/root-user-roles
=== PAUSE TestRoleCreate/error/root-user-roles
=== CONT  TestRoleCreate/error/root-user-roles
        --- PASS: TestRoleCreate/error/root-user-roles (0.00s)
=== RUN   TestRoleCreate/error/without-cloud
=== PAUSE TestRoleCreate/error/without-cloud
=== CONT  TestRoleCreate/error/without-cloud
        --- PASS: TestRoleCreate/error/without-cloud (0.00s)
=== RUN   TestRoleCreate/error/root-ttl
=== PAUSE TestRoleCreate/error/root-ttl
=== CONT  TestRoleCreate/error/root-ttl
        --- PASS: TestRoleCreate/error/root-ttl (0.00s)
=== RUN   TestRoleCreate/not-existing-cloud
=== PAUSE TestRoleCreate/not-existing-cloud
=== CONT  TestRoleCreate/not-existing-cloud
    --- PASS: TestRoleCreate/not-existing-cloud (0.00s)
=== RUN   TestRoleCreate/save-store-err
=== PAUSE TestRoleCreate/save-store-err
=== CONT  TestRoleCreate/save-store-err
    --- PASS: TestRoleCreate/save-store-err (0.00s)
=== RUN   TestRoleUpdate
=== PAUSE TestRoleUpdate
=== CONT  TestRoleUpdate
--- PASS: TestRoleUpdate (0.00s)
=== RUN   TestRoleUpdate/ok
    --- PASS: TestRoleUpdate/ok (0.00s)
=== RUN   TestRoleUpdate/not-existing
    --- PASS: TestRoleUpdate/not-existing (0.00s)
=== RUN   TestRotateRootCredentials_ok
--- PASS: TestRotateRootCredentials_ok (0.00s)
=== RUN   TestRotateRootCredentials_error
=== PAUSE TestRotateRootCredentials_error
=== CONT  TestRotateRootCredentials_error
--- PASS: TestRotateRootCredentials_error (0.01s)
=== RUN   TestRotateRootCredentials_error/read-fail
    --- PASS: TestRotateRootCredentials_error/read-fail (0.00s)
=== RUN   TestRotateRootCredentials_error/no-post
    --- PASS: TestRotateRootCredentials_error/no-post (0.00s)
=== RUN   TestRotateRootCredentials_error/no-get
    --- PASS: TestRotateRootCredentials_error/no-get (0.00s)
=== RUN   TestRotateRootCredentials_error/no-change
    --- PASS: TestRotateRootCredentials_error/no-change (0.00s)
PASS
ok  	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack	(cached)
?   	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack/fixtures	[no test files]

Process finished with the exit code 0
```
