### PR TITLE
Change `rotate-root` path method

### DIFF
--- a/acceptance/rotate_test.go
+++ b/acceptance/rotate_test.go
@@ -68,7 +68,7 @@ func (p *PluginTest) TestRootRotate() {
 	newCloud := p.makeChildCloud(cloud)
 
 	r, err := p.vaultDo(
-		http.MethodGet,
+		http.MethodPost,
 		fmt.Sprintf("/v1/%s/rotate-root/%s", pluginAlias, newCloud.Name),
 		nil,
 	)

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -117,6 +117,7 @@ Once this method is called, Vault will now be the only entity that knows the pas
 | Method | Path                            |
 |:-------|:--------------------------------|
 | `POST` | `/openstack/rotate-root/:cloud` |
+| `PUT`  | `/openstack/rotate-root/:cloud` |
 
 ### Sample Request
 

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -116,7 +116,7 @@ Once this method is called, Vault will now be the only entity that knows the pas
 
 | Method | Path                            |
 |:-------|:--------------------------------|
-| `GET`  | `/openstack/rotate-root/:cloud` |
+| `POST` | `/openstack/rotate-root/:cloud` |
 
 ### Sample Request
 

--- a/openstack/path_rotate_root.go
+++ b/openstack/path_rotate_root.go
@@ -34,7 +34,10 @@ func (b *backend) pathRotateRoot() *framework.Path {
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.rotateRootCredentials,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.rotateRootCredentials,
 			},
 		},

--- a/openstack/path_rotate_root_test.go
+++ b/openstack/path_rotate_root_test.go
@@ -36,7 +36,7 @@ func TestRotateRootCredentials_ok(t *testing.T) {
 
 	_, err = b.HandleRequest(context.Background(), &logical.Request{
 		Path:      "rotate-root/" + cloud.name,
-		Operation: logical.ReadOperation,
+		Operation: logical.CreateOperation,
 		Storage:   s,
 	})
 	require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestRotateRootCredentials_error(t *testing.T) {
 
 		_, err := b.HandleRequest(context.Background(), &logical.Request{
 			Path:      "rotate-root/" + cloud.name,
-			Operation: logical.ReadOperation,
+			Operation: logical.CreateOperation,
 			Storage:   s,
 		})
 		require.Error(t, err)
@@ -100,7 +100,7 @@ func TestRotateRootCredentials_error(t *testing.T) {
 
 			_, err = b.HandleRequest(context.Background(), &logical.Request{
 				Path:      "rotate-root/" + cloud.name,
-				Operation: logical.ReadOperation,
+				Operation: logical.CreateOperation,
 				Storage:   s,
 			})
 			require.Error(t, err)


### PR DESCRIPTION
## Description
Now `rotate-root` path works with `POST` and `PUT` instead of `GET`
Fixes: #80

## Acceptance tests
```
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
    roles_test.go:53: Cloud with name `dvjjx06ku3` was created
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== CONT  TestPlugin/TestRoleLifecycle
    plugin_test.go:337: Cloud with name `dvjjx06ku3` has been removed
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `qrh3` was created
    plugin_test.go:337: Cloud with name `qrh3` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
--- PASS: TestPlugin (11.94s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.38s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.38s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (4.87s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (1.21s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (2.01s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (0.78s)
    --- PASS: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.02s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (4.55s)
PASS
ok      github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   11.948s
```