### PR TITLE
Fix issue with cached outdated `token` in `client` 

### DIFF
--- a/acceptance/creds_test.go
+++ b/acceptance/creds_test.go
@@ -110,6 +110,14 @@ func (p *PluginTest) TestCredsLifecycle() {
 			assert.Equal(t, http.StatusOK, resp.StatusCode, readJSONResponse(t, resp))
 
 			resp, err = p.vaultDo(
+				http.MethodPost,
+				"/v1/sys/leases/revoke-force/openstack/creds",
+				nil,
+			)
+			require.NoError(t, err)
+			assertStatusCode(t, http.StatusNoContent, resp)
+
+			resp, err = p.vaultDo(
 				http.MethodDelete,
 				roleURL(roleName),
 				nil,

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -90,7 +90,7 @@ func (c *sharedCloud) getClient(ctx context.Context, s logical.Storage) (*gopher
 
 	if c.client != nil {
 		diff := time.Now().Sub(c.expiresAt)
-		if diff.Seconds() <= 120 {
+		if diff.Seconds() >= -120 && !c.expiresAt.IsZero() {
 			if err := c.initClient(ctx, s); err != nil {
 				return nil, err
 			}

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
-	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -86,21 +85,8 @@ func (c *sharedCloud) getClient(ctx context.Context, s logical.Storage) (*gopher
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if c.client != nil {
-		valid, err := tokens.Validate(c.client, c.client.Token())
-		if err != nil {
-			return nil, err
-		}
-
-		if !valid {
-			if err := c.initClient(ctx, s); err != nil {
-				return nil, err
-			}
-		}
-	} else {
-		if err := c.initClient(ctx, s); err != nil {
-			return nil, err
-		}
+	if err := c.initClient(ctx, s); err != nil {
+		return nil, err
 	}
 
 	return c.client, nil

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -3,12 +3,12 @@ package openstack
 import (
 	"context"
 	"fmt"
-	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"sync"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -90,15 +90,13 @@ func (c *sharedCloud) getClient(ctx context.Context, s logical.Storage) (*gopher
 
 	if c.client != nil {
 		diff := time.Now().Sub(c.expiresAt)
-		if diff.Seconds() >= -120 && !c.expiresAt.IsZero() {
-			if err := c.initClient(ctx, s); err != nil {
-				return nil, err
-			}
+		if diff.Seconds() <= -120 {
+			return c.client, nil
 		}
-	} else {
-		if err := c.initClient(ctx, s); err != nil {
-			return nil, err
-		}
+	}
+
+	if err := c.initClient(ctx, s); err != nil {
+		return nil, err
 	}
 
 	return c.client, nil

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -89,7 +89,7 @@ func (c *sharedCloud) getClient(ctx context.Context, s logical.Storage) (*gopher
 	defer c.lock.Unlock()
 
 	if c.client != nil {
-		diff := time.Now().Sub(c.expiresAt)
+		diff := time.Since(c.expiresAt)
 		if diff.Seconds() <= -120 {
 			return c.client, nil
 		}

--- a/openstack/backend_test.go
+++ b/openstack/backend_test.go
@@ -89,27 +89,6 @@ func TestSharedCloud_client(t *testing.T) {
 	testClient := thClient.ServiceClient()
 	_, s := testBackend(t)
 
-	t.Run("existing-client", func(t *testing.T) {
-		cloud := &sharedCloud{
-			client: thClient.ServiceClient(),
-			lock:   sync.Mutex{},
-		}
-
-		th.Mux.HandleFunc("/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
-			th.TestMethod(t, r, "HEAD")
-			th.TestHeaderUnset(t, r, "Content-Type")
-			th.TestHeader(t, r, "Accept", "application/json")
-			th.TestHeader(t, r, "X-Auth-Token", thClient.TokenID)
-			th.TestHeader(t, r, "X-Subject-Token", thClient.TokenID)
-
-			w.WriteHeader(http.StatusNoContent)
-		})
-
-		client, err := cloud.getClient(context.Background(), s)
-		assert.NoError(t, err)
-		assert.Equal(t, testClient, client)
-	})
-
 	t.Run("new-client", func(t *testing.T) {
 		authURL := testClient.Endpoint + "v3"
 

--- a/openstack/backend_test.go
+++ b/openstack/backend_test.go
@@ -89,16 +89,29 @@ func TestSharedCloud_client(t *testing.T) {
 	testClient := thClient.ServiceClient()
 	_, s := testBackend(t)
 
+	t.Run("existing-client", func(t *testing.T) {
+		cloud := &sharedCloud{
+			client: thClient.ServiceClient(),
+			lock:   sync.Mutex{},
+		}
+
+		client, err := cloud.getClient(context.Background(), s)
+		assert.NoError(t, err)
+		assert.Equal(t, testClient, client)
+	})
+
 	t.Run("new-client", func(t *testing.T) {
 		authURL := testClient.Endpoint + "v3"
 
 		th.Mux.HandleFunc("/v3/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
-			th.TestMethod(t, r, "POST")
-			th.TestHeader(t, r, "Content-Type", "application/json")
-			th.TestHeader(t, r, "Accept", "application/json")
+			switch r.Method {
+			case "POST":
+				th.TestMethod(t, r, "POST")
+				th.TestHeader(t, r, "Content-Type", "application/json")
+				th.TestHeader(t, r, "Accept", "application/json")
 
-			w.WriteHeader(http.StatusCreated)
-			_, _ = fmt.Fprintf(w, `
+				w.WriteHeader(http.StatusCreated)
+				_, _ = fmt.Fprintf(w, `
 {
   "token": {
     "expires_at": "2014-10-02T13:45:00.000000Z",
@@ -121,6 +134,18 @@ func TestSharedCloud_client(t *testing.T) {
   }
 }
 `, authURL)
+			case "GET":
+				th.TestMethod(t, r, "GET")
+
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprint(w, `
+{
+  "token": {
+    "expires_at": "2023-10-02T13:45:00.000000Z"
+  }
+}
+`)
+			}
 		})
 
 		cloud := &sharedCloud{name: tools.RandomString("cl", 5)}

--- a/openstack/backend_test.go
+++ b/openstack/backend_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
@@ -91,8 +92,9 @@ func TestSharedCloud_client(t *testing.T) {
 
 	t.Run("existing-client", func(t *testing.T) {
 		cloud := &sharedCloud{
-			client: thClient.ServiceClient(),
-			lock:   sync.Mutex{},
+			client:    thClient.ServiceClient(),
+			expiresAt: time.Now().Add(time.Hour),
+			lock:      sync.Mutex{},
 		}
 
 		client, err := cloud.getClient(context.Background(), s)


### PR DESCRIPTION
## Description
Reinit client to prevent use of outdated token
Refers to: #87

## Tests performed
### Acceptance tests
```
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
    roles_test.go:53: Cloud with name `jsrus8zg5u` was created
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== CONT  TestPlugin/TestRoleLifecycle
    plugin_test.go:337: Cloud with name `jsrus8zg5u` has been removed
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `qj6s` was created
    plugin_test.go:337: Cloud with name `qj6s` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
--- PASS: TestPlugin (14.02s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.36s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.36s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (8.31s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (2.05s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (3.27s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (2.14s)
    --- PASS: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.02s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (4.64s)
PASS
ok      github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   14.030s
```

### Unit tests
```
=== RUN   TestBackend_sharedCloud
--- PASS: TestBackend_sharedCloud (0.00s)
=== RUN   TestBackend_sharedCloud/existing
    --- PASS: TestBackend_sharedCloud/existing (0.00s)
=== RUN   TestBackend_sharedCloud/non-existing
    --- PASS: TestBackend_sharedCloud/non-existing (0.00s)
=== RUN   TestSharedCloud_client
--- PASS: TestSharedCloud_client (0.00s)
=== RUN   TestSharedCloud_client/new-client
    --- PASS: TestSharedCloud_client/new-client (0.00s)
=== RUN   TestCloudCreate
--- PASS: TestCloudCreate (0.00s)
=== RUN   TestCloudCreate/EmptyConfig
    --- PASS: TestCloudCreate/EmptyConfig (0.00s)
=== RUN   TestCloudCreate/Create
    --- PASS: TestCloudCreate/Create (0.00s)
=== RUN   TestCloudCreate/Update
    --- PASS: TestCloudCreate/Update (0.00s)
=== RUN   TestCloudCreate/Read
    --- PASS: TestCloudCreate/Read (0.00s)
=== RUN   TestCloudCreate/Delete
    --- PASS: TestCloudCreate/Delete (0.00s)
=== RUN   TestCloudCreate/List
    --- PASS: TestCloudCreate/List (0.00s)
=== RUN   TestCredentialsRead_ok
--- PASS: TestCredentialsRead_ok (0.01s)
=== RUN   TestCredentialsRead_ok/root_token
    --- PASS: TestCredentialsRead_ok/root_token (0.00s)
=== RUN   TestCredentialsRead_ok/user_token
    --- PASS: TestCredentialsRead_ok/user_token (0.00s)
=== RUN   TestCredentialsRead_ok/user_password
    --- PASS: TestCredentialsRead_ok/user_password (0.00s)
=== RUN   TestCredentialsRead_ok/token_revoke
    --- PASS: TestCredentialsRead_ok/token_revoke (0.00s)
=== RUN   TestCredentialsRead_ok/user_password_revoke
    --- PASS: TestCredentialsRead_ok/user_password_revoke (0.00s)
=== RUN   TestCredentialsRead_error
--- PASS: TestCredentialsRead_error (0.00s)
=== RUN   TestCredentialsRead_error/read-fail
    --- PASS: TestCredentialsRead_error/read-fail (0.00s)
=== RUN   TestCredentialsRead_error/no-user-post
    --- PASS: TestCredentialsRead_error/no-user-post (0.00s)
=== RUN   TestCredentialsRead_error/no-users-token-post
    --- PASS: TestCredentialsRead_error/no-users-token-post (0.00s)
=== RUN   TestCredentialsRevoke_error
--- PASS: TestCredentialsRevoke_error (0.00s)
=== RUN   TestCredentialsRevoke_error/no-token-delete
    --- PASS: TestCredentialsRevoke_error/no-token-delete (0.00s)
=== RUN   TestCredentialsRevoke_error/no-user-delete
    --- PASS: TestCredentialsRevoke_error/no-user-delete (0.00s)
=== RUN   TestInfoRead
=== PAUSE TestInfoRead
=== CONT  TestInfoRead
--- PASS: TestInfoRead (0.00s)
=== RUN   TestRoleStoragePath
--- PASS: TestRoleStoragePath (0.00s)
=== RUN   TestRoleGet
=== PAUSE TestRoleGet
=== CONT  TestRoleGet
--- PASS: TestRoleGet (0.00s)
=== RUN   TestRoleGet/existing
=== PAUSE TestRoleGet/existing
=== CONT  TestRoleGet/existing
    --- PASS: TestRoleGet/existing (0.00s)
=== RUN   TestRoleGet/not-existing
=== PAUSE TestRoleGet/not-existing
=== CONT  TestRoleGet/not-existing
    --- PASS: TestRoleGet/not-existing (0.00s)
=== RUN   TestRoleGet/get-err
=== PAUSE TestRoleGet/get-err
=== CONT  TestRoleGet/get-err
    --- PASS: TestRoleGet/get-err (0.00s)
=== RUN   TestRoleExistence
=== PAUSE TestRoleExistence
=== CONT  TestRoleExistence
--- PASS: TestRoleExistence (0.00s)
=== RUN   TestRoleExistence/existing
=== PAUSE TestRoleExistence/existing
=== CONT  TestRoleExistence/existing
    --- PASS: TestRoleExistence/existing (0.00s)
=== RUN   TestRoleExistence/not-existing
=== PAUSE TestRoleExistence/not-existing
=== CONT  TestRoleExistence/not-existing
    --- PASS: TestRoleExistence/not-existing (0.00s)
=== RUN   TestRoleExistence/get-err
=== PAUSE TestRoleExistence/get-err
=== CONT  TestRoleExistence/get-err
    --- PASS: TestRoleExistence/get-err (0.00s)
=== RUN   TestRoleList
=== PAUSE TestRoleList
=== CONT  TestRoleList
--- PASS: TestRoleList (0.00s)
=== RUN   TestRoleList/ok
    --- PASS: TestRoleList/ok (0.00s)
=== RUN   TestRoleList/error
=== PAUSE TestRoleList/error
=== CONT  TestRoleList/error
    --- PASS: TestRoleList/error (0.00s)
=== RUN   TestRoleList/filter
=== PAUSE TestRoleList/filter
=== CONT  TestRoleList/filter
    --- PASS: TestRoleList/filter (0.00s)
=== RUN   TestRoleList/filter-get-err
=== PAUSE TestRoleList/filter-get-err
=== CONT  TestRoleList/filter-get-err
    --- PASS: TestRoleList/filter-get-err (0.00s)
=== RUN   TestRoleDelete
=== PAUSE TestRoleDelete
=== CONT  TestRoleDelete
--- PASS: TestRoleDelete (0.00s)
=== RUN   TestRoleDelete/existing
=== PAUSE TestRoleDelete/existing
=== CONT  TestRoleDelete/existing
    --- PASS: TestRoleDelete/existing (0.00s)
=== RUN   TestRoleDelete/not-existing
=== PAUSE TestRoleDelete/not-existing
=== CONT  TestRoleDelete/not-existing
    --- PASS: TestRoleDelete/not-existing (0.00s)
=== RUN   TestRoleDelete/error
=== PAUSE TestRoleDelete/error
=== CONT  TestRoleDelete/error
    --- PASS: TestRoleDelete/error (0.00s)
=== RUN   TestRoleDelete/error-get
=== PAUSE TestRoleDelete/error-get
=== CONT  TestRoleDelete/error-get
    --- PASS: TestRoleDelete/error-get (0.00s)
=== RUN   TestRoleCreate
=== PAUSE TestRoleCreate
=== CONT  TestRoleCreate
--- PASS: TestRoleCreate (0.01s)
=== RUN   TestRoleCreate/ok
    --- PASS: TestRoleCreate/ok (0.00s)
=== RUN   TestRoleCreate/ok/admin
=== PAUSE TestRoleCreate/ok/admin
=== CONT  TestRoleCreate/ok/admin
        --- PASS: TestRoleCreate/ok/admin (0.00s)
=== RUN   TestRoleCreate/ok/token
=== PAUSE TestRoleCreate/ok/token
=== CONT  TestRoleCreate/ok/token
        --- PASS: TestRoleCreate/ok/token (0.00s)
=== RUN   TestRoleCreate/ok/password
=== PAUSE TestRoleCreate/ok/password
=== CONT  TestRoleCreate/ok/password
        --- PASS: TestRoleCreate/ok/password (0.00s)
=== RUN   TestRoleCreate/ok/ttl
=== PAUSE TestRoleCreate/ok/ttl
=== CONT  TestRoleCreate/ok/ttl
        --- PASS: TestRoleCreate/ok/ttl (0.00s)
=== RUN   TestRoleCreate/ok/endpoint-override
=== PAUSE TestRoleCreate/ok/endpoint-override
=== CONT  TestRoleCreate/ok/endpoint-override
        --- PASS: TestRoleCreate/ok/endpoint-override (0.00s)
=== RUN   TestRoleCreate/error
    --- PASS: TestRoleCreate/error (0.00s)
=== RUN   TestRoleCreate/error/root-ttl
=== PAUSE TestRoleCreate/error/root-ttl
=== CONT  TestRoleCreate/error/root-ttl
        --- PASS: TestRoleCreate/error/root-ttl (0.00s)
=== RUN   TestRoleCreate/error/root-password
=== PAUSE TestRoleCreate/error/root-password
=== CONT  TestRoleCreate/error/root-password
        --- PASS: TestRoleCreate/error/root-password (0.00s)
=== RUN   TestRoleCreate/error/root-user-groups
=== PAUSE TestRoleCreate/error/root-user-groups
=== CONT  TestRoleCreate/error/root-user-groups
        --- PASS: TestRoleCreate/error/root-user-groups (0.00s)
=== RUN   TestRoleCreate/error/root-user-roles
=== PAUSE TestRoleCreate/error/root-user-roles
=== CONT  TestRoleCreate/error/root-user-roles
        --- PASS: TestRoleCreate/error/root-user-roles (0.00s)
=== RUN   TestRoleCreate/error/without-cloud
=== PAUSE TestRoleCreate/error/without-cloud
=== CONT  TestRoleCreate/error/without-cloud
        --- PASS: TestRoleCreate/error/without-cloud (0.00s)
=== RUN   TestRoleCreate/not-existing-cloud
=== PAUSE TestRoleCreate/not-existing-cloud
=== CONT  TestRoleCreate/not-existing-cloud
    --- PASS: TestRoleCreate/not-existing-cloud (0.00s)
=== RUN   TestRoleCreate/save-store-err
=== PAUSE TestRoleCreate/save-store-err
=== CONT  TestRoleCreate/save-store-err
    --- PASS: TestRoleCreate/save-store-err (0.00s)
=== RUN   TestRoleUpdate
=== PAUSE TestRoleUpdate
=== CONT  TestRoleUpdate
--- PASS: TestRoleUpdate (0.00s)
=== RUN   TestRoleUpdate/ok
    --- PASS: TestRoleUpdate/ok (0.00s)
=== RUN   TestRoleUpdate/not-existing
    --- PASS: TestRoleUpdate/not-existing (0.00s)
=== RUN   TestRotateRootCredentials_ok
--- PASS: TestRotateRootCredentials_ok (0.00s)
=== RUN   TestRotateRootCredentials_error
=== PAUSE TestRotateRootCredentials_error
=== CONT  TestRotateRootCredentials_error
--- PASS: TestRotateRootCredentials_error (0.01s)
=== RUN   TestRotateRootCredentials_error/read-fail
    --- PASS: TestRotateRootCredentials_error/read-fail (0.00s)
=== RUN   TestRotateRootCredentials_error/no-get
    --- PASS: TestRotateRootCredentials_error/no-get (0.00s)
=== RUN   TestRotateRootCredentials_error/no-change
    --- PASS: TestRotateRootCredentials_error/no-change (0.00s)
=== RUN   TestRotateRootCredentials_error/no-post
    --- PASS: TestRotateRootCredentials_error/no-post (0.00s)
PASS
ok  	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack	(cached)

?   	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack/fixtures	[no test files]

Process finished with the exit code 0
```