### PR TITLE
Fix issue with empty `domain` value

### DIFF
--- a/openstack/path_creds.go
+++ b/openstack/path_creds.go
@@ -515,8 +515,14 @@ func formAuthResponse(role *roleEntry, authResponse *authResponseData) map[strin
 			}
 		}
 	default:
-		auth = map[string]interface{}{
-			"user_domain_id": authResponse.DomainID,
+		if role.Root {
+			auth = map[string]interface{}{
+				"user_domain_name": authResponse.DomainName,
+			}
+		} else {
+			auth = map[string]interface{}{
+				"user_domain_id": authResponse.DomainID,
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Fix issue with empty `user_domain_id` in domain scoped `creds` request.
Fixes: #94

## Tests performed
### Unit tests
```
=== RUN   TestBackend_sharedCloud
=== RUN   TestBackend_sharedCloud/existing
=== RUN   TestBackend_sharedCloud/non-existing
--- PASS: TestBackend_sharedCloud (0.00s)
    --- PASS: TestBackend_sharedCloud/existing (0.00s)
    --- PASS: TestBackend_sharedCloud/non-existing (0.00s)
=== RUN   TestSharedCloud_client
=== RUN   TestSharedCloud_client/existing-client
=== RUN   TestSharedCloud_client/new-client
--- PASS: TestSharedCloud_client (0.00s)
    --- PASS: TestSharedCloud_client/existing-client (0.00s)
    --- PASS: TestSharedCloud_client/new-client (0.00s)
=== RUN   TestCloudCreate
=== RUN   TestCloudCreate/EmptyConfig
=== RUN   TestCloudCreate/Create
=== RUN   TestCloudCreate/Update
=== RUN   TestCloudCreate/Read
=== RUN   TestCloudCreate/Delete
=== RUN   TestCloudCreate/List
--- PASS: TestCloudCreate (0.00s)
    --- PASS: TestCloudCreate/EmptyConfig (0.00s)
    --- PASS: TestCloudCreate/Create (0.00s)
    --- PASS: TestCloudCreate/Update (0.00s)
    --- PASS: TestCloudCreate/Read (0.00s)
    --- PASS: TestCloudCreate/Delete (0.00s)
    --- PASS: TestCloudCreate/List (0.00s)
=== RUN   TestCredentialsRead_ok
=== RUN   TestCredentialsRead_ok/root_token
=== RUN   TestCredentialsRead_ok/user_token
=== RUN   TestCredentialsRead_ok/user_password
=== RUN   TestCredentialsRead_ok/token_revoke
=== RUN   TestCredentialsRead_ok/user_password_revoke
--- PASS: TestCredentialsRead_ok (0.01s)
    --- PASS: TestCredentialsRead_ok/root_token (0.00s)
    --- PASS: TestCredentialsRead_ok/user_token (0.00s)
    --- PASS: TestCredentialsRead_ok/user_password (0.00s)
    --- PASS: TestCredentialsRead_ok/token_revoke (0.00s)
    --- PASS: TestCredentialsRead_ok/user_password_revoke (0.00s)
=== RUN   TestCredentialsRead_error
=== RUN   TestCredentialsRead_error/read-fail
=== RUN   TestCredentialsRead_error/no-user-post
=== RUN   TestCredentialsRead_error/no-users-token-post
--- PASS: TestCredentialsRead_error (0.00s)
    --- PASS: TestCredentialsRead_error/read-fail (0.00s)
    --- PASS: TestCredentialsRead_error/no-user-post (0.00s)
    --- PASS: TestCredentialsRead_error/no-users-token-post (0.00s)
=== RUN   TestCredentialsRevoke_error
=== RUN   TestCredentialsRevoke_error/no-token-delete
=== RUN   TestCredentialsRevoke_error/no-user-delete
--- PASS: TestCredentialsRevoke_error (0.00s)
    --- PASS: TestCredentialsRevoke_error/no-token-delete (0.00s)
    --- PASS: TestCredentialsRevoke_error/no-user-delete (0.00s)
=== RUN   TestInfoRead
=== PAUSE TestInfoRead
=== RUN   TestRoleStoragePath
--- PASS: TestRoleStoragePath (0.00s)
=== RUN   TestRoleGet
=== PAUSE TestRoleGet
=== RUN   TestRoleExistence
=== PAUSE TestRoleExistence
=== RUN   TestRoleList
=== PAUSE TestRoleList
=== RUN   TestRoleDelete
=== PAUSE TestRoleDelete
=== RUN   TestRoleCreate
=== PAUSE TestRoleCreate
=== RUN   TestRoleUpdate
=== PAUSE TestRoleUpdate
=== RUN   TestRotateRootCredentials_ok
--- PASS: TestRotateRootCredentials_ok (0.00s)
=== RUN   TestRotateRootCredentials_error
=== PAUSE TestRotateRootCredentials_error
=== CONT  TestInfoRead
=== CONT  TestRoleCreate
=== CONT  TestRoleList
=== CONT  TestRotateRootCredentials_error
=== RUN   TestRoleList/ok
=== RUN   TestRotateRootCredentials_error/read-fail
=== CONT  TestRoleUpdate
=== RUN   TestRoleCreate/ok
=== CONT  TestRoleDelete
=== RUN   TestRoleDelete/existing
=== RUN   TestRoleUpdate/ok
=== PAUSE TestRoleDelete/existing
=== RUN   TestRoleDelete/not-existing
=== CONT  TestRoleExistence
=== RUN   TestRoleExistence/existing
=== PAUSE TestRoleExistence/existing
=== RUN   TestRoleExistence/not-existing
=== PAUSE TestRoleExistence/not-existing
=== RUN   TestRoleExistence/get-err
--- PASS: TestInfoRead (0.00s)
=== CONT  TestRoleGet
=== RUN   TestRoleGet/existing
=== PAUSE TestRoleDelete/not-existing
=== PAUSE TestRoleGet/existing
=== RUN   TestRoleDelete/error
=== RUN   TestRoleGet/not-existing
=== PAUSE TestRoleGet/not-existing
=== RUN   TestRoleGet/get-err
=== PAUSE TestRoleDelete/error
=== PAUSE TestRoleGet/get-err
=== PAUSE TestRoleExistence/get-err
=== RUN   TestRoleDelete/error-get
=== RUN   TestRoleList/error
=== PAUSE TestRoleDelete/error-get
=== PAUSE TestRoleList/error
=== CONT  TestRoleGet/not-existing
=== RUN   TestRoleList/filter
=== PAUSE TestRoleList/filter
=== CONT  TestRoleGet/existing
=== RUN   TestRoleList/filter-get-err
=== PAUSE TestRoleList/filter-get-err
=== CONT  TestRoleExistence/get-err
=== CONT  TestRoleGet/get-err
=== RUN   TestRoleUpdate/not-existing
=== RUN   TestRoleCreate/ok/token
=== PAUSE TestRoleCreate/ok/token
=== RUN   TestRoleCreate/ok/password
=== PAUSE TestRoleCreate/ok/password
=== RUN   TestRoleCreate/ok/ttl
=== PAUSE TestRoleCreate/ok/ttl
=== RUN   TestRoleCreate/ok/username
=== PAUSE TestRoleCreate/ok/username
=== CONT  TestRoleExistence/existing
=== RUN   TestRoleCreate/ok/endpoint-override
=== CONT  TestRoleExistence/not-existing
=== CONT  TestRoleDelete/existing
=== CONT  TestRoleDelete/error-get
=== CONT  TestRoleDelete/error
--- PASS: TestRoleExistence (0.00s)
    --- PASS: TestRoleExistence/not-existing (0.00s)
    --- PASS: TestRoleExistence/get-err (0.00s)
    --- PASS: TestRoleExistence/existing (0.00s)
=== CONT  TestRoleDelete/not-existing
=== PAUSE TestRoleCreate/ok/endpoint-override
=== RUN   TestRoleCreate/ok/admin
=== PAUSE TestRoleCreate/ok/admin
=== CONT  TestRoleList/error
=== CONT  TestRoleList/filter-get-err
=== CONT  TestRoleList/filter
=== CONT  TestRoleCreate/ok/token
=== CONT  TestRoleCreate/ok/admin
--- PASS: TestRoleUpdate (0.00s)
    --- PASS: TestRoleUpdate/ok (0.00s)
    --- PASS: TestRoleUpdate/not-existing (0.00s)
=== CONT  TestRoleCreate/ok/endpoint-override
=== CONT  TestRoleCreate/ok/username
--- PASS: TestRoleGet (0.00s)
    --- PASS: TestRoleGet/not-existing (0.00s)
    --- PASS: TestRoleGet/get-err (0.00s)
    --- PASS: TestRoleGet/existing (0.00s)
--- PASS: TestRoleDelete (0.00s)
    --- PASS: TestRoleDelete/existing (0.00s)
    --- PASS: TestRoleDelete/error (0.00s)
    --- PASS: TestRoleDelete/not-existing (0.00s)
    --- PASS: TestRoleDelete/error-get (0.00s)
=== CONT  TestRoleCreate/ok/ttl
=== CONT  TestRoleCreate/ok/password
--- PASS: TestRoleList (0.00s)
    --- PASS: TestRoleList/ok (0.00s)
    --- PASS: TestRoleList/error (0.00s)
    --- PASS: TestRoleList/filter-get-err (0.00s)
    --- PASS: TestRoleList/filter (0.00s)
=== RUN   TestRotateRootCredentials_error/no-post
=== RUN   TestRoleCreate/error
=== RUN   TestRoleCreate/error/root-ttl
=== PAUSE TestRoleCreate/error/root-ttl
=== RUN   TestRoleCreate/error/root-password
=== PAUSE TestRoleCreate/error/root-password
=== RUN   TestRoleCreate/error/root-user-groups
=== PAUSE TestRoleCreate/error/root-user-groups
=== RUN   TestRoleCreate/error/root-user-roles
=== PAUSE TestRoleCreate/error/root-user-roles
=== RUN   TestRoleCreate/error/without-cloud
=== PAUSE TestRoleCreate/error/without-cloud
=== CONT  TestRoleCreate/error/root-ttl
=== CONT  TestRoleCreate/error/root-user-roles
=== CONT  TestRoleCreate/error/root-user-groups
=== CONT  TestRoleCreate/error/without-cloud
=== CONT  TestRoleCreate/error/root-password
=== RUN   TestRoleCreate/not-existing-cloud
=== PAUSE TestRoleCreate/not-existing-cloud
=== RUN   TestRoleCreate/save-store-err
=== PAUSE TestRoleCreate/save-store-err
=== CONT  TestRoleCreate/not-existing-cloud
=== CONT  TestRoleCreate/save-store-err
--- PASS: TestRoleCreate (0.01s)
    --- PASS: TestRoleCreate/ok (0.00s)
        --- PASS: TestRoleCreate/ok/token (0.00s)
        --- PASS: TestRoleCreate/ok/password (0.00s)
        --- PASS: TestRoleCreate/ok/admin (0.00s)
        --- PASS: TestRoleCreate/ok/ttl (0.00s)
        --- PASS: TestRoleCreate/ok/endpoint-override (0.00s)
        --- PASS: TestRoleCreate/ok/username (0.00s)
    --- PASS: TestRoleCreate/error (0.00s)
        --- PASS: TestRoleCreate/error/root-ttl (0.00s)
        --- PASS: TestRoleCreate/error/without-cloud (0.00s)
        --- PASS: TestRoleCreate/error/root-user-groups (0.00s)
        --- PASS: TestRoleCreate/error/root-user-roles (0.00s)
        --- PASS: TestRoleCreate/error/root-password (0.00s)
    --- PASS: TestRoleCreate/save-store-err (0.00s)
    --- PASS: TestRoleCreate/not-existing-cloud (0.00s)
=== RUN   TestRotateRootCredentials_error/no-get
=== RUN   TestRotateRootCredentials_error/no-change
--- PASS: TestRotateRootCredentials_error (0.01s)
    --- PASS: TestRotateRootCredentials_error/read-fail (0.00s)
    --- PASS: TestRotateRootCredentials_error/no-post (0.00s)
    --- PASS: TestRotateRootCredentials_error/no-get (0.00s)
    --- PASS: TestRotateRootCredentials_error/no-change (0.00s)
PASS
ok  	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack	0.741s
?   	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack/fixtures	[no test files]

Process finished with the exit code 0
```
