### PR TITLE
Vault: ``static-creds`` implementation

### DIFF
--- a/acceptance/static_creds_test.go
+++ b/acceptance/static_creds_test.go
@@ -1,0 +1,175 @@
+//go:build acceptance
+// +build acceptance
+
+package acceptance
+
+import (
+	"fmt"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
+	"github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack"
+	"github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack/fixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
+)
+
+type testStaticCase struct {
+	Cloud      string
+	ProjectID  string
+	DomainID   string
+	Root       bool
+	SecretType string
+	Username   string
+	Extensions map[string]interface{}
+}
+
+func (p *PluginTest) TestStaticCredsLifecycle() {
+	t := p.T()
+
+	cloud := openstackCloudConfig(t)
+	require.NotEmpty(t, cloud)
+
+	client, aux := openstackClient(t)
+
+	userRoleName := "member"
+
+	dataCloud := map[string]interface{}{
+		"auth_url":         cloud.AuthURL,
+		"username":         cloud.Username,
+		"password":         cloud.Password,
+		"user_domain_name": cloud.UserDomainName,
+	}
+
+	cases := map[string]testStaticCase{
+		"user_password": {
+			Cloud:      cloud.Name,
+			ProjectID:  aux.ProjectID,
+			DomainID:   aux.DomainID,
+			Username:   "static-test-1",
+			SecretType: "password",
+		},
+		"user_token": {
+			Cloud:      cloud.Name,
+			ProjectID:  aux.ProjectID,
+			DomainID:   aux.DomainID,
+			Username:   "static-test-2",
+			SecretType: "token",
+			Extensions: map[string]interface{}{
+				"identity_api_version": "3",
+			},
+		},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := data
+
+			roleName := openstack.RandomString(openstack.NameDefaultSet, 4)
+
+			resp, err := p.vaultDo(
+				http.MethodPost,
+				cloudURL(cloudName),
+				dataCloud,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNoContent, resp.StatusCode, readJSONResponse(t, resp))
+
+			createUserOpts := users.CreateOpts{
+				Name:             data.Username,
+				Description:      "Static user",
+				DefaultProjectID: aux.ProjectID,
+				DomainID:         aux.DomainID,
+				Password:         openstack.RandomString(openstack.PwdDefaultSet, 16),
+			}
+			user, err := users.Create(client, createUserOpts).Extract()
+			require.NoError(t, err)
+
+			rolesToAdd, err := filterRole(client, userRoleName)
+			require.NoError(t, err)
+
+			assignOpts := roles.AssignOpts{
+				UserID:    user.ID,
+				ProjectID: aux.ProjectID,
+			}
+
+			err = roles.Assign(client, rolesToAdd.ID, assignOpts).ExtractErr()
+			require.NoError(t, err)
+
+			resp, err = p.vaultDo(
+				http.MethodPost,
+				staticRoleURL(roleName),
+				cloudToStaticRoleMap(data),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusNoContent, resp.StatusCode, readJSONResponse(t, resp))
+
+			resp, err = p.vaultDo(
+				http.MethodGet,
+				staticRoleURL(roleName),
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, readJSONResponse(t, resp))
+
+			resp, err = p.vaultDo(
+				http.MethodGet,
+				staticCredsURL(roleName),
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, readJSONResponse(t, resp))
+
+			resp, err = p.vaultDo(
+				http.MethodDelete,
+				staticRoleURL(roleName),
+				nil,
+			)
+			require.NoError(t, err)
+			assertStatusCode(t, http.StatusNoContent, resp)
+
+			resp, err = p.vaultDo(
+				http.MethodDelete,
+				cloudURL(cloudName),
+				nil,
+			)
+			require.NoError(t, err)
+			assertStatusCode(t, http.StatusNoContent, resp)
+
+			t.Cleanup(func() {
+				require.NoError(t, users.Delete(client, user.ID).ExtractErr())
+			})
+		})
+	}
+}
+
+func staticCredsURL(roleName string) string {
+	return fmt.Sprintf("/v1/openstack/static-creds/%s", roleName)
+}
+
+func cloudToStaticRoleMap(data testStaticCase) map[string]interface{} {
+	return fixtures.SanitizedMap(map[string]interface{}{
+		"cloud":       data.Cloud,
+		"project_id":  data.ProjectID,
+		"domain_id":   data.DomainID,
+		"secret_type": data.SecretType,
+		"username":    data.Username,
+		"extensions":  data.Extensions,
+	})
+}
+
+func filterRole(client *gophercloud.ServiceClient, roleName string) (*roles.Role, error) {
+	rolePages, err := roles.List(client, roles.ListOpts{Name: roleName}).AllPages()
+	if err != nil {
+		return nil, fmt.Errorf("unable to query roles: %w", err)
+	}
+
+	roleList, err := roles.ExtractRoles(rolePages)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve roles: %w", err)
+	}
+
+	return &roleList[0], nil
+}

--- a/acceptance/static_creds_test.go
+++ b/acceptance/static_creds_test.go
@@ -68,7 +68,7 @@ func (p *PluginTest) TestStaticCredsLifecycle() {
 
 			roleName := openstack.RandomString(openstack.NameDefaultSet, 4)
 
-			userId := userSetup(t, client, data, aux, userRoleName, allRoles)
+			userId := userSetup(t, client, data, aux, allRoles[userRoleName])
 			t.Cleanup(func() {
 				require.NoError(t, users.Delete(client, userId).ExtractErr())
 			})
@@ -155,7 +155,7 @@ func getAllRoles(t *testing.T, client *gophercloud.ServiceClient) map[string]rol
 	return result
 }
 
-func userSetup(t *testing.T, client *gophercloud.ServiceClient, data testStaticCase, aux *AuxiliaryData, userRoleName string, role map[string]roles.Role) string {
+func userSetup(t *testing.T, client *gophercloud.ServiceClient, data testStaticCase, aux *AuxiliaryData, role roles.Role) string {
 	createUserOpts := users.CreateOpts{
 		Name:             data.username,
 		Description:      "Static user",
@@ -171,7 +171,7 @@ func userSetup(t *testing.T, client *gophercloud.ServiceClient, data testStaticC
 		ProjectID: aux.ProjectID,
 	}
 
-	err = roles.Assign(client, role[userRoleName].ID, assignOpts).ExtractErr()
+	err = roles.Assign(client, role.ID, assignOpts).ExtractErr()
 	require.NoError(t, err)
 
 	return user.ID

--- a/acceptance/static_creds_test.go
+++ b/acceptance/static_creds_test.go
@@ -68,7 +68,7 @@ func (p *PluginTest) TestStaticCredsLifecycle() {
 
 			roleName := openstack.RandomString(openstack.NameDefaultSet, 4)
 
-			userId := userSetup(t, client, data, aux, allRoles[userRoleName])
+			userId := userSetup(t, client, data, aux, allRoles[userRoleName].ID)
 			t.Cleanup(func() {
 				require.NoError(t, users.Delete(client, userId).ExtractErr())
 			})
@@ -155,7 +155,7 @@ func getAllRoles(t *testing.T, client *gophercloud.ServiceClient) map[string]rol
 	return result
 }
 
-func userSetup(t *testing.T, client *gophercloud.ServiceClient, data testStaticCase, aux *AuxiliaryData, role roles.Role) string {
+func userSetup(t *testing.T, client *gophercloud.ServiceClient, data testStaticCase, aux *AuxiliaryData, roleID string) string {
 	createUserOpts := users.CreateOpts{
 		Name:             data.username,
 		Description:      "Static user",
@@ -171,7 +171,7 @@ func userSetup(t *testing.T, client *gophercloud.ServiceClient, data testStaticC
 		ProjectID: aux.ProjectID,
 	}
 
-	err = roles.Assign(client, role.ID, assignOpts).ExtractErr()
+	err = roles.Assign(client, roleID, assignOpts).ExtractErr()
 	require.NoError(t, err)
 
 	return user.ID

--- a/acceptance/static_roles_test.go
+++ b/acceptance/static_roles_test.go
@@ -71,6 +71,10 @@ func (p *PluginTest) TestStaticRoleLifecycle() {
 	user, err := users.Create(client, createUserOpts).Extract()
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		require.NoError(t, users.Delete(client, user.ID).ExtractErr())
+	})
+
 	data := expectedStaticRoleData(cloud.Name, aux)
 	roleName := "test-write"
 	t.Run("WriteRole", func(t *testing.T) {
@@ -101,10 +105,6 @@ func (p *PluginTest) TestStaticRoleLifecycle() {
 			Username:         data["username"].(string),
 		}
 		assert.Equal(t, expected, extractStaticRoleData(t, resp))
-	})
-
-	t.Cleanup(func() {
-		require.NoError(t, users.Delete(client, user.ID).ExtractErr())
 	})
 
 	t.Run("ListRoles", func(t *testing.T) {

--- a/acceptance/static_roles_test.go
+++ b/acceptance/static_roles_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 	"github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +24,6 @@ type staticRoleData struct {
 	ProjectID        string                 `json:"project_id"`
 	ProjectName      string                 `json:"project_name"`
 	Extensions       map[string]interface{} `json:"extensions"`
-	Root             bool                   `json:"root"`
 	SecretType       string                 `json:"secret_type"`
 	Username         string                 `json:"username"`
 }
@@ -42,17 +42,36 @@ func extractStaticRoleData(t *testing.T, resp *http.Response) *staticRoleData {
 func (p *PluginTest) TestStaticRoleLifecycle() {
 	t := p.T()
 
-	cloud := &openstack.OsCloud{
-		Name:             openstack.RandomString(openstack.NameDefaultSet, 10),
-		AuthURL:          "https://example.com/v3",
-		UserDomainName:   openstack.RandomString(openstack.NameDefaultSet, 10),
-		Username:         openstack.RandomString(openstack.NameDefaultSet, 10),
-		Password:         openstack.RandomString(openstack.PwdDefaultSet, 10),
-		UsernameTemplate: "u-{{ .RoleName }}-{{ random 4 }}",
-	}
-	p.makeCloud(cloud)
+	cloud := openstackCloudConfig(t)
+	require.NotEmpty(t, cloud)
 
-	data := expectedStaticRoleData(cloud.Name)
+	client, aux := openstackClient(t)
+
+	dataCloud := map[string]interface{}{
+		"auth_url":         cloud.AuthURL,
+		"username":         cloud.Username,
+		"password":         cloud.Password,
+		"user_domain_name": cloud.UserDomainName,
+	}
+
+	resp, err := p.vaultDo(
+		http.MethodPost,
+		cloudURL(cloudName),
+		dataCloud,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode, readJSONResponse(t, resp))
+
+	createUserOpts := users.CreateOpts{
+		Name:        "vault-test",
+		Description: "Static user",
+		DomainID:    aux.DomainID,
+		Password:    openstack.RandomString(openstack.PwdDefaultSet, 16),
+	}
+	user, err := users.Create(client, createUserOpts).Extract()
+	require.NoError(t, err)
+
+	data := expectedStaticRoleData(cloud.Name, aux)
 	roleName := "test-write"
 	t.Run("WriteRole", func(t *testing.T) {
 		resp, err := p.vaultDo(
@@ -74,16 +93,18 @@ func (p *PluginTest) TestStaticRoleLifecycle() {
 
 		expected := &staticRoleData{
 			Cloud:            data["cloud"].(string),
-			TTL:              data["ttl"].(time.Duration),
 			RotationDuration: data["rotation_duration"].(time.Duration),
 			ProjectID:        data["project_id"].(string),
 			ProjectName:      data["project_name"].(string),
 			Extensions:       data["extensions"].(map[string]interface{}),
-			Root:             data["root"].(bool),
 			SecretType:       data["secret_type"].(string),
 			Username:         data["username"].(string),
 		}
 		assert.Equal(t, expected, extractStaticRoleData(t, resp))
+	})
+
+	t.Cleanup(func() {
+		require.NoError(t, users.Delete(client, user.ID).ExtractErr())
 	})
 
 	t.Run("ListRoles", func(t *testing.T) {
@@ -112,17 +133,17 @@ func staticRoleURL(name string) string {
 	return fmt.Sprintf("/v1/openstack/static-role/%s", name)
 }
 
-func expectedStaticRoleData(cloudName string) map[string]interface{} {
+func expectedStaticRoleData(cloudName string, aux *AuxiliaryData) map[string]interface{} {
 	expectedMap := map[string]interface{}{
 		"cloud":             cloudName,
 		"ttl":               time.Hour / time.Second,
 		"rotation_duration": time.Hour / time.Second,
-		"project_id":        "",
+		"project_id":        aux.ProjectID,
+		"domain_id":         aux.DomainID,
 		"project_name":      tools.RandomString("p", 5),
 		"extensions":        map[string]interface{}{},
-		"root":              false,
 		"secret_type":       "password",
-		"username":          "static-test",
+		"username":          "vault-test",
 	}
 	return expectedMap
 }

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -440,10 +440,6 @@ created. If the role exists, it will be updated with the new attributes.
 
 - `username` `(string: <required>)` - Specifies username of user managed by the static role.
 
-- `root` `(bool: <optional>)` - Specifies whenever to use the root user as a role actor.
-  If set to `true`, `secret_type` can't be set to `password`.
-  If set to `true`, `ttl` value is ignored.
-
 - `rotation_duration` `(string: "1h")` - Specifies password rotation time value for the static user as a
   string duration with time suffix.
 
@@ -487,17 +483,6 @@ $ curl \
 ```json
 {
   "cloud": "example-cloud",
-  "project_name": "test",
-  "username": "test-user"
-}
-```
-
-#### Creating a static role using root user
-
-```json
-{
-  "cloud": "example-cloud",
-  "root": true,
   "project_name": "test",
   "username": "test-user"
 }
@@ -582,6 +567,77 @@ $ curl \
       "default-cloud-role-1",
       "default-cloud-role-2"
     ]
+  }
+}
+```
+
+## Read Static Role Credentials
+
+This endpoint returns user credentials based on the named static role.
+
+| Method   | Path                            |
+|:---------|:--------------------------------|
+| `GET`    | `/openstack/static-creds/:name` |
+
+### Parameters
+
+- `name` (`string: <required>`) - Specifies the name of the role to return credentials against.
+
+### Sample Request
+
+```shell
+$ curl \
+    --header "X-Vault-Token: ..." \
+    http://127.0.0.1:8200/v1/openstack/static-creds/example-role
+```
+
+### Sample Responses
+
+#### Credentials for the token-type static role
+
+```json
+{
+  "data": {
+    "auth": {
+      "auth_url": "https://example.com/v3/",
+      "token": "gAAAAABiA6Xfybumdwd84qvMDJKYOaauWxSvG9ItslSr5w0Mb...",
+      "project_name": "test",
+      "project_domain_id": "Default"
+    },
+    "auth_type": "token"
+  }
+}
+```
+
+#### Credentials for the password-type static role with project scope
+
+```json
+{
+  "data": {
+    "auth": {
+      "auth_url": "https://example.com/v3/",
+      "username": "admin",
+      "password": "RcigTiYrJjVmEkrV71Cd",
+      "project_name": "test",
+      "project_domain_id": "Default"
+    },
+    "auth_type": "password"
+  }
+}
+```
+
+#### Credentials for the password-type static role with domain scope
+
+```json
+{
+  "data": {
+    "auth": {
+      "auth_url": "https://example.com/v3/",
+      "username": "admin",
+      "password": "RcigTiYrJjVmEkrV71Cd",
+      "user_domain_id": "Default"
+    },
+    "auth_type": "password"
   }
 }
 ```

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -54,6 +54,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 			b.pathStaticRole(),
 			b.pathRotateRoot(),
 			b.pathCreds(),
+			b.pathStaticCreds(),
 		},
 		Secrets: []*framework.Secret{
 			secretToken(b),

--- a/openstack/fixtures/helpers.go
+++ b/openstack/fixtures/helpers.go
@@ -129,7 +129,7 @@ func handleCreateUser(t *testing.T, w http.ResponseWriter, r *http.Request, user
         "links": {
             "self": "https://example.com/identity/v3/users/%[1]s"
         },
-        "name": "James_Doe",
+        "name": "James Doe",
         "password_expires_at": "2016-11-06T15:32:17.000000"
     }
 }
@@ -156,7 +156,7 @@ func handleUpdateUser(t *testing.T, w http.ResponseWriter, r *http.Request, user
         "links": {
             "self": "https://example.com/identity/v3/users/29148f9awu90f1u2"
         },
-        "name": "James_Doe",
+        "name": "James Doe",
         "password_expires_at": "2016-11-06T15:32:17.000000"
     }
 }

--- a/openstack/path_static_creds.go
+++ b/openstack/path_static_creds.go
@@ -157,12 +157,10 @@ func formStaticAuthResponse(role *roleStaticEntry, authResponse *authStaticRespo
 			"project_id": role.ProjectID,
 		}
 	case role.ProjectName != "":
-
 		auth = map[string]interface{}{
 			"project_name":      role.ProjectName,
 			"project_domain_id": authResponse.DomainID,
 		}
-
 	default:
 
 		auth = map[string]interface{}{

--- a/openstack/path_static_creds.go
+++ b/openstack/path_static_creds.go
@@ -1,0 +1,215 @@
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	pathStaticCreds = "static-creds"
+
+	staticCredsHelpSyn  = "Manage the Openstack static credentials with static roles."
+	staticCredsHelpDesc = `
+This path allows you to read OpenStack secret stored by predefined static roles.
+`
+)
+
+func (b *backend) pathStaticCreds() *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("%s/%s", pathStaticCreds, framework.GenericNameRegex("role")),
+		Fields: map[string]*framework.FieldSchema{
+			"role": {
+				Type:        framework.TypeString,
+				Description: "Name of the role.",
+				Required:    true,
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathStaticCredsRead,
+			},
+		},
+		HelpSynopsis:    staticCredsHelpSyn,
+		HelpDescription: staticCredsHelpDesc,
+	}
+}
+
+func (b *backend) pathStaticCredsRead(ctx context.Context, r *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	roleName := d.Get("role").(string)
+	role, err := getStaticRoleByName(ctx, roleName, r)
+	if err != nil {
+		return nil, err
+	}
+
+	sharedCloud := b.getSharedCloud(role.Cloud)
+	cloudConfig, err := sharedCloud.getCloudConfig(ctx, r.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := sharedCloud.getClient(ctx, r.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	var data map[string]interface{}
+	switch r := role.SecretType; r {
+	case SecretToken:
+		tokenOpts := &tokens.AuthOptions{
+			Username: role.Username,
+			Password: role.Secret,
+			DomainID: role.DomainID,
+			Scope:    getScopeFromStaticRole(role),
+		}
+
+		token, err := createToken(client, tokenOpts)
+		if err != nil {
+			return nil, err
+		}
+
+		authResponse := &authStaticResponseData{
+			AuthURL:  cloudConfig.AuthURL,
+			Username: role.Username,
+			Token:    token.ID,
+			DomainID: role.DomainID,
+		}
+
+		data = map[string]interface{}{
+			"auth": formStaticAuthResponse(
+				role,
+				authResponse,
+			),
+			"auth_type": "token",
+		}
+
+	case SecretPassword:
+		authResponse := &authStaticResponseData{
+			AuthURL:  cloudConfig.AuthURL,
+			Username: role.Username,
+			Password: role.Secret,
+			DomainID: role.DomainID,
+		}
+		data = map[string]interface{}{
+			"auth": formStaticAuthResponse(
+				role,
+				authResponse,
+			),
+			"auth_type": "password",
+		}
+
+	default:
+		return nil, fmt.Errorf("invalid secret type: %s", r)
+	}
+
+	for extensionKey, extensionValue := range role.Extensions {
+		data[extensionKey] = extensionValue
+	}
+
+	return &logical.Response{Data: data}, nil
+}
+
+func getScopeFromStaticRole(role *roleStaticEntry) tokens.Scope {
+	var scope tokens.Scope
+	switch {
+	case role.ProjectID != "":
+		scope = tokens.Scope{
+			ProjectID: role.ProjectID,
+		}
+	case role.ProjectName != "":
+		scope = tokens.Scope{
+			ProjectName: role.ProjectName,
+			DomainName:  role.DomainName,
+			DomainID:    role.DomainID,
+		}
+	case role.DomainID != "":
+		scope = tokens.Scope{
+			DomainID: role.DomainID,
+		}
+	case role.DomainName != "":
+		scope = tokens.Scope{
+			DomainName: role.DomainName,
+		}
+	default:
+		scope = tokens.Scope{}
+	}
+	return scope
+}
+
+type authStaticResponseData struct {
+	AuthURL    string
+	Username   string
+	Password   string
+	Token      string
+	DomainID   string
+	DomainName string
+}
+
+func formStaticAuthResponse(role *roleStaticEntry, authResponse *authStaticResponseData) map[string]interface{} {
+	var auth map[string]interface{}
+
+	switch {
+	case role.ProjectID != "":
+		auth = map[string]interface{}{
+			"project_id": role.ProjectID,
+		}
+	case role.ProjectName != "":
+
+		auth = map[string]interface{}{
+			"project_name":      role.ProjectName,
+			"project_domain_id": authResponse.DomainID,
+		}
+
+	default:
+
+		auth = map[string]interface{}{
+			"user_domain_id": authResponse.DomainID,
+		}
+	}
+
+	if authResponse.Token != "" {
+		auth["token"] = authResponse.Token
+	} else {
+		auth["username"] = authResponse.Username
+		auth["password"] = authResponse.Password
+	}
+
+	auth["auth_url"] = authResponse.AuthURL
+
+	return auth
+}
+
+func (b *backend) rotateUserPassword(ctx context.Context, req *logical.Request, cloud *sharedCloud, user string, password string) (string, error) {
+	var userId string
+	client, err := cloud.getClient(ctx, req.Storage)
+	if err != nil {
+		return userId, err
+	}
+	opts := users.ListOpts{Name: user}
+	allPages, err := users.List(client, opts).AllPages()
+	if err != nil {
+		return userId, fmt.Errorf("provided user doesn't exist")
+	}
+
+	allUsers, err := users.ExtractUsers(allPages)
+	if err != nil {
+		return userId, fmt.Errorf("page can't be extracted for given username: %s (%s)", user, err)
+	}
+
+	if len(allUsers) > 1 {
+		return userId, fmt.Errorf("given username is not unique")
+	} else if len(allUsers) == 0 {
+		return userId, fmt.Errorf("user `%s` doesn't exist", user)
+	}
+
+	userId = allUsers[0].ID
+
+	_, err = users.Update(client, userId, users.UpdateOpts{Password: password}).Extract()
+	if err != nil {
+		return userId, fmt.Errorf("error rotating user password for user `%s`: %s", user, err)
+	}
+	return userId, nil
+}

--- a/openstack/path_static_creds_test.go
+++ b/openstack/path_static_creds_test.go
@@ -1,0 +1,163 @@
+package openstack
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/acceptance/tools"
+	thClient "github.com/gophercloud/gophercloud/testhelper/client"
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/vault/sdk/logical"
+	"github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack/fixtures"
+	"github.com/stretchr/testify/require"
+)
+
+func credsStaticPath(name string) string {
+	return fmt.Sprintf("%s/%s", "static-creds", name)
+}
+
+func TestStaticCredentialsRead_ok(t *testing.T) {
+	userID, _ := uuid.GenerateUUID()
+	secret, _ := uuid.GenerateUUID()
+	projectName := tools.RandomString("p", 5)
+
+	fixtures.SetupKeystoneMock(t, userID, projectName, fixtures.EnabledMocks{
+		TokenPost: true,
+		TokenGet:  true,
+		UserList:  true,
+	})
+
+	testClient := thClient.ServiceClient()
+	authURL := testClient.Endpoint + "v3"
+
+	b, s := testBackend(t)
+	cloudEntry, err := logical.StorageEntryJSON(storageCloudKey(testCloudName), &OsCloud{
+		Name:             testCloudName,
+		AuthURL:          authURL,
+		UserDomainName:   testUserDomainName,
+		Username:         testUsername,
+		Password:         testPassword1,
+		UsernameTemplate: testTemplate1,
+	})
+	require.NoError(t, err)
+
+	t.Run("user_token", func(t *testing.T) {
+		require.NoError(t, s.Put(context.Background(), cloudEntry))
+
+		roleName := createSaveRandomStaticRole(t, s, projectName, "token", secret)
+
+		res, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      credsStaticPath(roleName),
+			Storage:   s,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Data)
+	})
+	t.Run("user_password", func(t *testing.T) {
+		require.NoError(t, s.Put(context.Background(), cloudEntry))
+
+		roleName := createSaveRandomStaticRole(t, s, projectName, "password", secret)
+
+		res, err := b.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.ReadOperation,
+			Path:      credsStaticPath(roleName),
+			Storage:   s,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, res.Data)
+	})
+}
+
+func TestStaticCredentialsRead_error(t *testing.T) {
+	t.Run("read-fail", func(t *testing.T) {
+		userID, _ := uuid.GenerateUUID()
+		secret, _ := uuid.GenerateUUID()
+		fixtures.SetupKeystoneMock(t, userID, "", fixtures.EnabledMocks{})
+
+		b, s := testBackend(t, failVerbRead)
+
+		roleName := createSaveRandomStaticRole(t, s, "", "token", secret)
+
+		_, err := b.HandleRequest(context.Background(), &logical.Request{
+			Path:      credsStaticPath(roleName),
+			Operation: logical.ReadOperation,
+			Storage:   s,
+		})
+		require.Error(t, err)
+	})
+
+	type testCase struct {
+		EnabledMocks fixtures.EnabledMocks
+		ProjectName  string
+		ServiceType  string
+	}
+
+	cases := map[string]testCase{
+		"no-token-post": {
+			EnabledMocks: fixtures.EnabledMocks{
+				TokenGet: true,
+			},
+			ProjectName: tools.RandomString("p", 5),
+			ServiceType: "token",
+		},
+		"no-token-get": {
+			EnabledMocks: fixtures.EnabledMocks{
+				TokenPost: true,
+			},
+			ProjectName: tools.RandomString("p", 5),
+			ServiceType: "token",
+		},
+	}
+
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			data := data
+			userID, _ := uuid.GenerateUUID()
+			secret, _ := uuid.GenerateUUID()
+			fixtures.SetupKeystoneMock(t, userID, data.ProjectName, data.EnabledMocks)
+
+			b, s := testBackend(t)
+
+			roleName := createSaveRandomStaticRole(t, s, data.ProjectName, data.ServiceType, secret)
+
+			testClient := thClient.ServiceClient()
+			authURL := testClient.Endpoint + "v3"
+
+			cloudEntry, err := logical.StorageEntryJSON(storageCloudKey(testCloudName), &OsCloud{
+				Name:             testCloudName,
+				AuthURL:          authURL,
+				UserDomainName:   testUserDomainName,
+				Username:         testUsername,
+				Password:         testPassword1,
+				UsernameTemplate: testTemplate1,
+			})
+			require.NoError(t, err)
+			require.NoError(t, s.Put(context.Background(), cloudEntry))
+
+			_, err = b.HandleRequest(context.Background(), &logical.Request{
+				Operation: logical.ReadOperation,
+				Path:      credsStaticPath(roleName),
+				Storage:   s,
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+func createSaveRandomStaticRole(t *testing.T, s logical.Storage, projectName, sType string, secret string) string {
+	roleName := randomRoleName()
+	role := map[string]interface{}{
+		"name":         roleName,
+		"cloud":        testCloudName,
+		"project_name": projectName,
+		"domain_id":    tools.RandomString("d", 5),
+		"secret_type":  sType,
+		"secret":       secret,
+		"username":     roleName,
+	}
+	saveRawStaticRole(t, roleName, role, s)
+
+	return roleName
+}

--- a/openstack/path_static_role.go
+++ b/openstack/path_static_role.go
@@ -85,6 +85,10 @@ func (b *backend) pathStaticRole() *framework.Path {
 				Type:        framework.TypeNameString,
 				Description: "Specifies a username for static role.",
 			},
+			"user_id": {
+				Type:        framework.TypeNameString,
+				Description: "Internal field with static user id for further user management. Set once on role creation",
+			},
 			"project_id": {
 				Type:        framework.TypeLowerCaseString,
 				Description: "Specifies a project ID for project-scoped role.",

--- a/openstack/path_static_role.go
+++ b/openstack/path_static_role.go
@@ -147,7 +147,7 @@ type roleStaticEntry struct {
 	SecretType       secretType        `json:"secret_type"`
 	Secret           string            `json:"secret"`
 	Username         string            `json:"username"`
-	UserId           string            `json:"user_id"`
+	UserID           string            `json:"user_id"`
 	ProjectID        string            `json:"project_id"`
 	ProjectName      string            `json:"project_name"`
 	DomainID         string            `json:"domain_id"`
@@ -266,7 +266,7 @@ func (b *backend) pathStaticRoleUpdate(ctx context.Context, req *logical.Request
 			return logical.ErrorResponse("error during role creation: %s", err), nil
 		}
 
-		entry.UserId = userId
+		entry.UserID = userId
 		entry.Secret = password
 
 	} else if req.Operation == logical.CreateOperation {

--- a/openstack/path_static_role.go
+++ b/openstack/path_static_role.go
@@ -65,11 +65,21 @@ func (b *backend) pathStaticRole() *framework.Path {
 				Description: "Specifies the duration of static role password rotation.",
 				Default:     "1h",
 			},
+			"ttl": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Internal field which specifies the remaining time for the next password rotation.",
+				Default:     "1h",
+			},
 			"secret_type": {
 				Type:          framework.TypeLowerCaseString,
 				Description:   "Specifies what kind of secret will configuration contain.",
 				AllowedValues: []interface{}{"token", "password"},
 				Default:       SecretToken,
+			},
+			"secret": {
+				Type: framework.TypeString,
+				Description: "Internal field for Openstack user password which will be rotated " +
+					"upon static role creation.",
 			},
 			"username": {
 				Type:        framework.TypeNameString,

--- a/openstack/path_static_role.go
+++ b/openstack/path_static_role.go
@@ -215,12 +215,12 @@ func (b *backend) pathStaticRoleUpdate(ctx context.Context, req *logical.Request
 		}
 	}
 
-	scloud := b.getSharedCloud(cloudName)
-	cld, err := scloud.getCloudConfig(ctx, req.Storage)
+	cloud := b.getSharedCloud(cloudName)
+	cloudConfig, err := cloud.getCloudConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
-	if cld == nil {
+	if cloudConfig == nil {
 		return logical.ErrorResponse("cloud `%s` doesn't exist", cloudName), nil
 	}
 
@@ -247,7 +247,7 @@ func (b *backend) pathStaticRoleUpdate(ctx context.Context, req *logical.Request
 			return nil, err
 		}
 
-		userId, err := b.rotateUserPassword(ctx, req, scloud, username.(string), password)
+		userId, err := b.rotateUserPassword(ctx, req, cloud, username.(string), password)
 		if err != nil {
 			return logical.ErrorResponse("error during role creation: %s", err), nil
 		}

--- a/openstack/path_static_role_test.go
+++ b/openstack/path_static_role_test.go
@@ -534,6 +534,6 @@ func fillExpectedStaticRoleDefaultFields(b *backend, entry *roleStaticEntry) {
 
 func fillActualStaticRoleDefaultFields(entry *roleStaticEntry) {
 	entry.Secret = ""
-	entry.UserId = ""
+	entry.UserID = ""
 	entry.TTL = 0
 }

--- a/openstack/path_static_role_test.go
+++ b/openstack/path_static_role_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud/acceptance/tools"
+	thClient "github.com/gophercloud/gophercloud/testhelper/client"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -37,13 +38,11 @@ func expectedStaticRoleData(cloudName string) (*roleStaticEntry, map[string]inte
 	}
 	expectedMap := map[string]interface{}{
 		"cloud":             expected.Cloud,
-		"ttl":               expTTL,
 		"project_id":        "",
 		"project_name":      expected.ProjectName,
 		"domain_id":         "",
 		"domain_name":       expected.DomainName,
 		"extensions":        map[string]string{},
-		"root":              false,
 		"rotation_duration": expTTL,
 		"secret_type":       "token",
 		"username":          "static-test",
@@ -194,7 +193,7 @@ func TestStaticRoleList(t *testing.T) {
 		b, s := testBackend(t, failVerbList)
 		_, err := b.HandleRequest(context.Background(), &logical.Request{
 			Operation: logical.ListOperation,
-			Path:      "roles/",
+			Path:      "static-roles/",
 			Storage:   s,
 		})
 		require.Error(t, err)
@@ -292,7 +291,7 @@ func TestStaticRoleDelete(t *testing.T) {
 	})
 
 	t.Run("error-get", func(t *testing.T) {
-		t.Parallel()
+		//t.Parallel()
 		b, s := testBackend(t, failVerbRead)
 
 		roleName := randomRoleName()
@@ -309,49 +308,61 @@ func TestStaticRoleDelete(t *testing.T) {
 }
 
 func TestStaticRoleCreate(t *testing.T) {
+	username := "James_Doe"
+	userID, _ := uuid.GenerateUUID()
+
+	fixtures.SetupKeystoneMock(t, userID, username, fixtures.EnabledMocks{
+		TokenPost: true,
+		TokenGet:  true,
+		UserPatch: true,
+		UserList:  true,
+	})
+
+	testClient := thClient.ServiceClient()
+	authURL := testClient.Endpoint + "v3"
+
+	b, s := testBackend(t)
+	cloudEntry, err := logical.StorageEntryJSON(storageCloudKey(testCloudName), &OsCloud{
+		Name:             testCloudName,
+		AuthURL:          authURL,
+		UserDomainName:   testUserDomainName,
+		Username:         testUsername,
+		Password:         testPassword1,
+		UsernameTemplate: testTemplate1,
+	})
+	require.NoError(t, err)
+
 	t.Parallel()
-	username := tools.RandomString("user", 5)
-	id, _ := uuid.GenerateUUID()
+
 	t.Run("ok", func(t *testing.T) {
 
-		b, s := testBackend(t)
-		cloudName := preCreateCloud(t, s)
-
 		cases := map[string]*roleStaticEntry{
-			"admin": {
-				Name:     randomRoleName(),
-				Cloud:    cloudName,
-				Root:     true,
-				Username: username,
-			},
 			"token": {
 				Name:        randomRoleName(),
-				Cloud:       cloudName,
+				Cloud:       testCloudName,
 				ProjectName: randomRoleName(),
 				SecretType:  SecretToken,
 				Username:    username,
 			},
 			"password": {
 				Name:        randomRoleName(),
-				Cloud:       cloudName,
+				Cloud:       testCloudName,
 				ProjectName: randomRoleName(),
 				SecretType:  SecretPassword,
 				Username:    username,
 			},
 			"rotation_duration": {
 				Name:             randomRoleName(),
-				Cloud:            cloudName,
+				Cloud:            testCloudName,
 				ProjectName:      randomRoleName(),
 				SecretType:       SecretToken,
 				Username:         username,
 				RotationDuration: 24 * time.Hour,
-				TTL:              24 * time.Hour,
 			},
 			"endpoint-override": {
-				Name:      randomRoleName(),
-				Cloud:     cloudName,
-				Username:  username,
-				ProjectID: id,
+				Name:     randomRoleName(),
+				Cloud:    testCloudName,
+				Username: username,
 				Extensions: map[string]string{
 					"volume_api_version":             "3",
 					"object_store_endpoint_override": "https://swift.example.com",
@@ -363,7 +374,7 @@ func TestStaticRoleCreate(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				data := data
 				t.Parallel()
-
+				require.NoError(t, s.Put(context.Background(), cloudEntry))
 				roleName := data.Name
 				inputRole := fixtures.SanitizedMap(staticRoleToMap(data))
 
@@ -382,7 +393,8 @@ func TestStaticRoleCreate(t *testing.T) {
 				role := new(roleStaticEntry)
 				assert.NoError(t, entry.DecodeJSON(role))
 
-				fillStaticRoleDefaultFields(b, data) // otherwise there will be false positives
+				fillActualStaticRoleDefaultFields(role)
+				fillExpectedStaticRoleDefaultFields(b, data) // otherwise there will be false positives
 				assert.Equal(t, data, role)
 			})
 		}
@@ -397,25 +409,13 @@ func TestStaticRoleCreate(t *testing.T) {
 		b, s := testBackend(t)
 		cloudName := preCreateCloud(t, s)
 
-		notForRootRe := regexp.MustCompile(`impossible to set .+ for the root user`)
 		cases := map[string]*errRoleEntry{
-			"root-ttl": {
+			"username": {
 				roleStaticEntry: &roleStaticEntry{
 					Cloud:            cloudName,
-					Username:         username,
-					Root:             true,
 					RotationDuration: 1 * time.Hour,
 				},
-				errorRegex: notForRootRe,
-			},
-			"root-password": {
-				roleStaticEntry: &roleStaticEntry{
-					Cloud:      cloudName,
-					Username:   username,
-					Root:       true,
-					SecretType: SecretPassword,
-				},
-				errorRegex: notForRootRe,
+				errorRegex: regexp.MustCompile(`username is required when creating a static role`),
 			},
 			"without-cloud": {
 				roleStaticEntry: &roleStaticEntry{},
@@ -519,18 +519,21 @@ func TestStaticRoleUpdate(t *testing.T) {
 	})
 }
 
-func fillStaticRoleDefaultFields(b *backend, entry *roleStaticEntry) {
+func fillExpectedStaticRoleDefaultFields(b *backend, entry *roleStaticEntry) {
 	pr := b.pathStaticRole()
 	flds := pr.Fields
 	if entry.SecretType == "" {
 		entry.SecretType = flds["secret_type"].Default.(secretType)
 	}
-	if !entry.Root {
-		if entry.RotationDuration == 0 {
-			entry.RotationDuration = time.Hour
-			entry.TTL = time.Hour
-		}
+
+	if entry.RotationDuration == 0 {
+		entry.RotationDuration = time.Hour
 	}
-	entry.TTL /= time.Second
 	entry.RotationDuration /= time.Second
+}
+
+func fillActualStaticRoleDefaultFields(entry *roleStaticEntry) {
+	entry.Secret = ""
+	entry.UserId = ""
+	entry.TTL = 0
 }

--- a/openstack/path_static_role_test.go
+++ b/openstack/path_static_role_test.go
@@ -291,7 +291,7 @@ func TestStaticRoleDelete(t *testing.T) {
 	})
 
 	t.Run("error-get", func(t *testing.T) {
-		//t.Parallel()
+		t.Parallel()
 		b, s := testBackend(t, failVerbRead)
 
 		roleName := randomRoleName()


### PR DESCRIPTION
This PR add ``static-creds`` read path and relevant acceptance/unit tests, api documentation.
``static-roles`` logic was also updated.

Acceptance tests (failing on unrelated ``info`` test):
-----------------------------------------------------
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestInfo
    info_test.go:42: 
                Error Trace:    info_test.go:42
                Error:          Should NOT be empty, but was &{    }
                Test:           TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
    roles_test.go:53: Cloud with name `sjz3x3v53l` was created
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== CONT  TestPlugin/TestRoleLifecycle
    plugin_test.go:337: Cloud with name `sjz3x3v53l` has been removed
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `9jy7` was created
    plugin_test.go:337: Cloud with name `9jy7` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
=== RUN   TestPlugin/TestStaticCredsLifecycle
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_password
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token
=== RUN   TestPlugin/TestStaticRoleLifecycle
=== RUN   TestPlugin/TestStaticRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestStaticRoleLifecycle/DeleteRole
--- FAIL: TestPlugin (21.57s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.09s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.08s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (6.18s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (1.95s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (2.19s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (0.98s)
    --- FAIL: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.01s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (5.21s)
    --- PASS: TestPlugin/TestStaticCredsLifecycle (6.76s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_password (2.87s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token (3.06s)
    --- PASS: TestPlugin/TestStaticRoleLifecycle (3.17s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/WriteRole (1.23s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ReadRole (0.01s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/DeleteRole (0.00s)
FAIL
FAIL    github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   22.159s
FAIL
make: *** [functional] Error 1


Unit tests:
------------------------
=== RUN   TestBackend_sharedCloud
=== RUN   TestBackend_sharedCloud/existing
=== RUN   TestBackend_sharedCloud/non-existing
--- PASS: TestBackend_sharedCloud (0.00s)
    --- PASS: TestBackend_sharedCloud/existing (0.00s)
    --- PASS: TestBackend_sharedCloud/non-existing (0.00s)
=== RUN   TestSharedCloud_client
=== RUN   TestSharedCloud_client/existing-client
=== RUN   TestSharedCloud_client/new-client
--- PASS: TestSharedCloud_client (0.00s)
    --- PASS: TestSharedCloud_client/existing-client (0.00s)
    --- PASS: TestSharedCloud_client/new-client (0.00s)
=== RUN   TestCloudCreate
=== RUN   TestCloudCreate/EmptyConfig
=== RUN   TestCloudCreate/Create
=== RUN   TestCloudCreate/Update
=== RUN   TestCloudCreate/Read
=== RUN   TestCloudCreate/Delete
=== RUN   TestCloudCreate/List
--- PASS: TestCloudCreate (0.00s)
    --- PASS: TestCloudCreate/EmptyConfig (0.00s)
    --- PASS: TestCloudCreate/Create (0.00s)
    --- PASS: TestCloudCreate/Update (0.00s)
    --- PASS: TestCloudCreate/Read (0.00s)
    --- PASS: TestCloudCreate/Delete (0.00s)
    --- PASS: TestCloudCreate/List (0.00s)
=== RUN   TestCredentialsRead_ok
=== RUN   TestCredentialsRead_ok/root_token
=== RUN   TestCredentialsRead_ok/user_token
=== RUN   TestCredentialsRead_ok/user_password
=== RUN   TestCredentialsRead_ok/token_revoke
=== RUN   TestCredentialsRead_ok/user_password_revoke
--- PASS: TestCredentialsRead_ok (0.01s)
    --- PASS: TestCredentialsRead_ok/root_token (0.00s)
    --- PASS: TestCredentialsRead_ok/user_token (0.00s)
    --- PASS: TestCredentialsRead_ok/user_password (0.00s)
    --- PASS: TestCredentialsRead_ok/token_revoke (0.00s)
    --- PASS: TestCredentialsRead_ok/user_password_revoke (0.00s)
=== RUN   TestCredentialsRead_error
=== RUN   TestCredentialsRead_error/read-fail
=== RUN   TestCredentialsRead_error/no-user-post
=== RUN   TestCredentialsRead_error/no-users-token-post
--- PASS: TestCredentialsRead_error (0.00s)
    --- PASS: TestCredentialsRead_error/read-fail (0.00s)
    --- PASS: TestCredentialsRead_error/no-user-post (0.00s)
    --- PASS: TestCredentialsRead_error/no-users-token-post (0.00s)
=== RUN   TestCredentialsRevoke_error
=== RUN   TestCredentialsRevoke_error/no-token-delete
=== RUN   TestCredentialsRevoke_error/no-user-delete
--- PASS: TestCredentialsRevoke_error (0.00s)
    --- PASS: TestCredentialsRevoke_error/no-token-delete (0.00s)
    --- PASS: TestCredentialsRevoke_error/no-user-delete (0.00s)
=== RUN   TestInfoRead
=== PAUSE TestInfoRead
=== RUN   TestRoleStoragePath
--- PASS: TestRoleStoragePath (0.00s)
=== RUN   TestRoleGet
=== PAUSE TestRoleGet
=== RUN   TestRoleExistence
=== PAUSE TestRoleExistence
=== RUN   TestRoleList
=== PAUSE TestRoleList
=== RUN   TestRoleDelete
=== PAUSE TestRoleDelete
=== RUN   TestRoleCreate
=== PAUSE TestRoleCreate
=== RUN   TestRoleUpdate
=== PAUSE TestRoleUpdate
=== RUN   TestRotateRootCredentials_ok
--- PASS: TestRotateRootCredentials_ok (0.00s)
=== RUN   TestRotateRootCredentials_error
=== PAUSE TestRotateRootCredentials_error
=== RUN   TestStaticCredentialsRead_ok
=== RUN   TestStaticCredentialsRead_ok/user_token
=== RUN   TestStaticCredentialsRead_ok/user_password
--- PASS: TestStaticCredentialsRead_ok (0.00s)
    --- PASS: TestStaticCredentialsRead_ok/user_token (0.00s)
    --- PASS: TestStaticCredentialsRead_ok/user_password (0.00s)
=== RUN   TestStaticCredentialsRead_error
=== RUN   TestStaticCredentialsRead_error/read-fail
=== RUN   TestStaticCredentialsRead_error/no-token-post
=== RUN   TestStaticCredentialsRead_error/no-token-get
--- PASS: TestStaticCredentialsRead_error (0.00s)
    --- PASS: TestStaticCredentialsRead_error/read-fail (0.00s)
    --- PASS: TestStaticCredentialsRead_error/no-token-post (0.00s)
    --- PASS: TestStaticCredentialsRead_error/no-token-get (0.00s)
=== RUN   TestStaticRoleStoragePath
--- PASS: TestStaticRoleStoragePath (0.00s)
=== RUN   TestStaticRoleGet
=== PAUSE TestStaticRoleGet
=== RUN   TestStaticRoleExistence
=== PAUSE TestStaticRoleExistence
=== RUN   TestStaticRoleList
=== PAUSE TestStaticRoleList
=== RUN   TestStaticRoleDelete
=== PAUSE TestStaticRoleDelete
=== RUN   TestStaticRoleCreate
=== PAUSE TestStaticRoleCreate
=== RUN   TestStaticRoleUpdate
=== PAUSE TestStaticRoleUpdate
=== CONT  TestInfoRead
=== CONT  TestRotateRootCredentials_error
=== RUN   TestRotateRootCredentials_error/read-fail
=== CONT  TestStaticRoleDelete
=== CONT  TestStaticRoleUpdate
=== CONT  TestRoleDelete
=== RUN   TestRoleDelete/existing
=== CONT  TestStaticRoleExistence
=== CONT  TestRoleCreate
=== CONT  TestStaticRoleGet
=== PAUSE TestRoleDelete/existing
=== RUN   TestRoleDelete/not-existing
=== CONT  TestStaticRoleCreate
=== RUN   TestStaticRoleCreate/ok
=== PAUSE TestRoleDelete/not-existing
=== RUN   TestStaticRoleExistence/existing
=== RUN   TestStaticRoleCreate/ok/token
=== PAUSE TestStaticRoleCreate/ok/token
=== RUN   TestStaticRoleCreate/ok/password
=== PAUSE TestStaticRoleExistence/existing
=== RUN   TestStaticRoleExistence/not-existing
=== RUN   TestStaticRoleUpdate/ok
=== RUN   TestStaticRoleDelete/existing
=== PAUSE TestStaticRoleDelete/existing
=== RUN   TestRoleCreate/ok
--- PASS: TestInfoRead (0.00s)
=== CONT  TestRoleExistence
=== RUN   TestRoleExistence/existing
=== PAUSE TestRoleExistence/existing
=== RUN   TestRoleExistence/not-existing
=== PAUSE TestRoleExistence/not-existing
=== RUN   TestRoleExistence/get-err
=== PAUSE TestRoleExistence/get-err
=== RUN   TestRotateRootCredentials_error/no-change
=== CONT  TestRoleList
=== RUN   TestRoleList/ok
=== RUN   TestStaticRoleGet/existing
=== RUN   TestRoleDelete/error
=== RUN   TestStaticRoleDelete/not-existing
=== CONT  TestRoleUpdate
=== RUN   TestRoleCreate/ok/admin
=== PAUSE TestRoleCreate/ok/admin
=== RUN   TestRoleCreate/ok/token
=== PAUSE TestRoleCreate/ok/token
=== RUN   TestRoleCreate/ok/password
=== PAUSE TestRoleCreate/ok/password
=== PAUSE TestStaticRoleCreate/ok/password
=== RUN   TestRoleUpdate/ok
=== RUN   TestStaticRoleCreate/ok/rotation_duration
=== PAUSE TestStaticRoleCreate/ok/rotation_duration
=== RUN   TestStaticRoleCreate/ok/endpoint-override
=== PAUSE TestStaticRoleCreate/ok/endpoint-override
=== PAUSE TestStaticRoleExistence/not-existing
=== RUN   TestStaticRoleExistence/get-err
=== PAUSE TestStaticRoleExistence/get-err
=== CONT  TestRoleGet
=== RUN   TestRoleGet/existing
=== PAUSE TestRoleGet/existing
=== RUN   TestRoleGet/not-existing
=== PAUSE TestRoleGet/not-existing
=== RUN   TestRoleGet/get-err
=== PAUSE TestRoleGet/get-err
=== PAUSE TestStaticRoleGet/existing
=== RUN   TestStaticRoleGet/not-existing
=== PAUSE TestStaticRoleGet/not-existing
=== RUN   TestRoleList/error
=== CONT  TestRoleExistence/existing
=== PAUSE TestRoleList/error
=== RUN   TestRoleList/filter
=== PAUSE TestRoleList/filter
=== RUN   TestRoleList/filter-get-err
=== PAUSE TestRoleList/filter-get-err
=== RUN   TestStaticRoleGet/get-err
=== PAUSE TestStaticRoleGet/get-err
=== CONT  TestRoleExistence/get-err
=== RUN   TestStaticRoleUpdate/not-existing
=== CONT  TestStaticRoleCreate/ok/token
=== PAUSE TestStaticRoleDelete/not-existing
=== RUN   TestStaticRoleDelete/error
=== PAUSE TestStaticRoleDelete/error
=== RUN   TestStaticRoleDelete/error-get
=== RUN   TestRoleUpdate/not-existing
=== RUN   TestRoleCreate/ok/ttl
=== PAUSE TestRoleCreate/ok/ttl
=== RUN   TestRoleCreate/ok/endpoint-override
=== PAUSE TestRoleCreate/ok/endpoint-override
=== CONT  TestRoleGet/existing
=== CONT  TestRoleExistence/not-existing
=== PAUSE TestRoleDelete/error
=== RUN   TestRoleDelete/error-get
=== PAUSE TestRoleDelete/error-get
--- PASS: TestStaticRoleUpdate (0.00s)
    --- PASS: TestStaticRoleUpdate/ok (0.00s)
    --- PASS: TestStaticRoleUpdate/not-existing (0.00s)
=== CONT  TestStaticRoleCreate/ok/rotation_duration
--- PASS: TestRoleUpdate (0.00s)
    --- PASS: TestRoleUpdate/ok (0.00s)
    --- PASS: TestRoleUpdate/not-existing (0.00s)
=== CONT  TestStaticRoleExistence/not-existing
--- PASS: TestRoleExistence (0.00s)
    --- PASS: TestRoleExistence/get-err (0.00s)
    --- PASS: TestRoleExistence/existing (0.00s)
    --- PASS: TestRoleExistence/not-existing (0.00s)
=== CONT  TestRoleList/error
=== CONT  TestStaticRoleExistence/get-err
=== CONT  TestStaticRoleGet/existing
=== CONT  TestStaticRoleExistence/existing
=== CONT  TestRoleGet/get-err
=== CONT  TestStaticRoleList
=== CONT  TestStaticRoleCreate/ok/password
=== CONT  TestStaticRoleCreate/ok/endpoint-override
=== CONT  TestRoleGet/not-existing
=== RUN   TestStaticRoleList/ok
=== CONT  TestRoleCreate/ok/admin
=== CONT  TestRoleList/filter-get-err
=== RUN   TestStaticRoleList/error
=== PAUSE TestStaticRoleList/error
=== RUN   TestStaticRoleList/filter
=== PAUSE TestStaticRoleList/filter
=== RUN   TestStaticRoleList/filter-get-err
=== PAUSE TestStaticRoleList/filter-get-err
=== CONT  TestRoleList/filter
--- PASS: TestStaticRoleExistence (0.00s)
    --- PASS: TestStaticRoleExistence/not-existing (0.00s)
    --- PASS: TestStaticRoleExistence/get-err (0.00s)
    --- PASS: TestStaticRoleExistence/existing (0.00s)
=== CONT  TestStaticRoleGet/not-existing
=== CONT  TestStaticRoleGet/get-err
=== CONT  TestRoleCreate/ok/ttl
=== CONT  TestRoleCreate/ok/endpoint-override
--- PASS: TestRoleList (0.00s)
    --- PASS: TestRoleList/ok (0.00s)
    --- PASS: TestRoleList/error (0.00s)
    --- PASS: TestRoleList/filter-get-err (0.00s)
    --- PASS: TestRoleList/filter (0.00s)
=== CONT  TestRoleCreate/ok/password
=== CONT  TestRoleCreate/ok/token
=== CONT  TestRoleDelete/existing
--- PASS: TestStaticRoleGet (0.00s)
    --- PASS: TestStaticRoleGet/existing (0.00s)
    --- PASS: TestStaticRoleGet/get-err (0.00s)
    --- PASS: TestStaticRoleGet/not-existing (0.00s)
=== CONT  TestStaticRoleDelete/existing
=== CONT  TestRoleDelete/error
=== CONT  TestRoleDelete/not-existing
=== CONT  TestStaticRoleDelete/not-existing
=== CONT  TestRoleDelete/error-get
=== CONT  TestStaticRoleDelete/error
--- PASS: TestRoleGet (0.00s)
    --- PASS: TestRoleGet/existing (0.00s)
    --- PASS: TestRoleGet/get-err (0.00s)
    --- PASS: TestRoleGet/not-existing (0.00s)
=== CONT  TestStaticRoleList/error
=== CONT  TestStaticRoleList/filter-get-err
=== CONT  TestStaticRoleList/filter
=== RUN   TestRoleCreate/error
--- PASS: TestRoleDelete (0.00s)
    --- PASS: TestRoleDelete/existing (0.00s)
    --- PASS: TestRoleDelete/error (0.00s)
    --- PASS: TestRoleDelete/error-get (0.00s)
    --- PASS: TestRoleDelete/not-existing (0.00s)
=== RUN   TestRoleCreate/error/root-ttl
--- PASS: TestStaticRoleDelete (0.00s)
    --- PASS: TestStaticRoleDelete/error-get (0.00s)
    --- PASS: TestStaticRoleDelete/existing (0.00s)
    --- PASS: TestStaticRoleDelete/not-existing (0.00s)
    --- PASS: TestStaticRoleDelete/error (0.00s)
=== PAUSE TestRoleCreate/error/root-ttl
=== RUN   TestRoleCreate/error/root-password
=== PAUSE TestRoleCreate/error/root-password
=== RUN   TestRoleCreate/error/root-user-groups
=== PAUSE TestRoleCreate/error/root-user-groups
=== RUN   TestRoleCreate/error/root-user-roles
=== PAUSE TestRoleCreate/error/root-user-roles
=== RUN   TestRoleCreate/error/without-cloud
=== PAUSE TestRoleCreate/error/without-cloud
=== CONT  TestRoleCreate/error/root-ttl
=== CONT  TestRoleCreate/error/without-cloud
--- PASS: TestStaticRoleList (0.00s)
    --- PASS: TestStaticRoleList/ok (0.00s)
    --- PASS: TestStaticRoleList/error (0.00s)
    --- PASS: TestStaticRoleList/filter-get-err (0.00s)
    --- PASS: TestStaticRoleList/filter (0.00s)
=== CONT  TestRoleCreate/error/root-user-groups
=== CONT  TestRoleCreate/error/root-password
=== CONT  TestRoleCreate/error/root-user-roles
=== RUN   TestRoleCreate/not-existing-cloud
=== PAUSE TestRoleCreate/not-existing-cloud
=== RUN   TestRoleCreate/save-store-err
=== PAUSE TestRoleCreate/save-store-err
=== CONT  TestRoleCreate/not-existing-cloud
=== CONT  TestRoleCreate/save-store-err
--- PASS: TestRoleCreate (0.00s)
    --- PASS: TestRoleCreate/ok (0.00s)
        --- PASS: TestRoleCreate/ok/admin (0.00s)
        --- PASS: TestRoleCreate/ok/ttl (0.00s)
        --- PASS: TestRoleCreate/ok/endpoint-override (0.00s)
        --- PASS: TestRoleCreate/ok/password (0.00s)
        --- PASS: TestRoleCreate/ok/token (0.00s)
    --- PASS: TestRoleCreate/error (0.00s)
        --- PASS: TestRoleCreate/error/root-ttl (0.00s)
        --- PASS: TestRoleCreate/error/without-cloud (0.00s)
        --- PASS: TestRoleCreate/error/root-user-groups (0.00s)
        --- PASS: TestRoleCreate/error/root-user-roles (0.00s)
        --- PASS: TestRoleCreate/error/root-password (0.00s)
    --- PASS: TestRoleCreate/save-store-err (0.00s)
    --- PASS: TestRoleCreate/not-existing-cloud (0.00s)
=== RUN   TestRotateRootCredentials_error/no-post
=== RUN   TestRotateRootCredentials_error/no-get
--- PASS: TestRotateRootCredentials_error (0.01s)
    --- PASS: TestRotateRootCredentials_error/read-fail (0.00s)
    --- PASS: TestRotateRootCredentials_error/no-change (0.00s)
    --- PASS: TestRotateRootCredentials_error/no-post (0.00s)
    --- PASS: TestRotateRootCredentials_error/no-get (0.00s)
=== RUN   TestStaticRoleCreate/error
=== RUN   TestStaticRoleCreate/error/username
=== PAUSE TestStaticRoleCreate/error/username
=== RUN   TestStaticRoleCreate/error/without-cloud
=== PAUSE TestStaticRoleCreate/error/without-cloud
=== CONT  TestStaticRoleCreate/error/username
=== CONT  TestStaticRoleCreate/error/without-cloud
=== RUN   TestStaticRoleCreate/not-existing-cloud
=== PAUSE TestStaticRoleCreate/not-existing-cloud
=== RUN   TestStaticRoleCreate/save-store-err
=== PAUSE TestStaticRoleCreate/save-store-err
=== CONT  TestStaticRoleCreate/not-existing-cloud
=== CONT  TestStaticRoleCreate/save-store-err
--- PASS: TestStaticRoleCreate (0.01s)
    --- PASS: TestStaticRoleCreate/ok (0.00s)
        --- PASS: TestStaticRoleCreate/ok/token (0.00s)
        --- PASS: TestStaticRoleCreate/ok/rotation_duration (0.00s)
        --- PASS: TestStaticRoleCreate/ok/password (0.00s)
        --- PASS: TestStaticRoleCreate/ok/endpoint-override (0.00s)
    --- PASS: TestStaticRoleCreate/error (0.00s)
        --- PASS: TestStaticRoleCreate/error/username (0.00s)
        --- PASS: TestStaticRoleCreate/error/without-cloud (0.00s)
    --- PASS: TestStaticRoleCreate/save-store-err (0.00s)
    --- PASS: TestStaticRoleCreate/not-existing-cloud (0.00s)
PASS
ok  	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack	0.404s
?   	github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack/fixtures	[no test files]

Process finished with the exit code 0