### PR TITLE
Vault: fix static token generation when ``domain_name``/``domain_id`` are specified

### DIFF
--- a/acceptance/static_creds_test.go
+++ b/acceptance/static_creds_test.go
@@ -16,12 +16,13 @@ import (
 )
 
 type testStaticCase struct {
-	cloud      string
-	projectID  string
-	domainID   string
-	secretType string
-	username   string
-	extensions map[string]interface{}
+	cloud       string
+	projectID   string
+	projectName string
+	domainID    string
+	secretType  string
+	username    string
+	extensions  map[string]interface{}
 }
 
 func (p *PluginTest) TestStaticCredsLifecycle() {
@@ -50,12 +51,21 @@ func (p *PluginTest) TestStaticCredsLifecycle() {
 			username:   "static-test-1",
 			secretType: "password",
 		},
-		"user_token": {
+		"user_token_project_id": {
 			cloud:      cloud.Name,
 			projectID:  aux.ProjectID,
-			domainID:   aux.DomainID,
 			username:   "static-test-2",
 			secretType: "token",
+			extensions: map[string]interface{}{
+				"identity_api_version": "3",
+			},
+		},
+		"user_token_project_name": {
+			cloud:       cloud.Name,
+			projectName: "myproject",
+			domainID:    aux.DomainID,
+			username:    "static-test-3",
+			secretType:  "token",
 			extensions: map[string]interface{}{
 				"identity_api_version": "3",
 			},
@@ -142,12 +152,13 @@ func staticRotateCredsURL(roleName string) string {
 
 func cloudToStaticRoleMap(data testStaticCase) map[string]interface{} {
 	return fixtures.SanitizedMap(map[string]interface{}{
-		"cloud":       data.cloud,
-		"project_id":  data.projectID,
-		"domain_id":   data.domainID,
-		"secret_type": data.secretType,
-		"username":    data.username,
-		"extensions":  data.extensions,
+		"cloud":        data.cloud,
+		"project_id":   data.projectID,
+		"project_name": data.projectName,
+		"domain_id":    data.domainID,
+		"secret_type":  data.secretType,
+		"username":     data.username,
+		"extensions":   data.extensions,
 	})
 }
 

--- a/openstack/fixtures/helpers.go
+++ b/openstack/fixtures/helpers.go
@@ -163,6 +163,32 @@ func handleUpdateUser(t *testing.T, w http.ResponseWriter, r *http.Request, user
 `, userID)
 }
 
+func handleGetUser(t *testing.T, w http.ResponseWriter, r *http.Request, userID string) {
+	t.Helper()
+
+	th.TestHeader(t, r, "Accept", "application/json")
+	th.TestMethod(t, r, "GET")
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, `
+{
+    "user": {
+        "default_project_id": "project",
+        "description": "James Doe user",
+        "domain_id": "domain",
+        "email": "jdoe@example.com",
+        "enabled": true,
+        "id": "%s",
+        "links": {
+            "self": "https://example.com/identity/v3/users/29148f9awu90f1u2"
+        },
+        "name": "James Doe",
+        "password_expires_at": "2016-11-06T15:32:17.000000"
+    }
+}
+`, userID)
+}
+
 func handleListUsers(t *testing.T, w http.ResponseWriter, r *http.Request, userID string, userName string) {
 	t.Helper()
 
@@ -242,6 +268,7 @@ type EnabledMocks struct {
 	UserPatch      bool
 	UserList       bool
 	UserDelete     bool
+	UserGet        bool
 }
 
 func SetupKeystoneMock(t *testing.T, userID, projectName string, enabled EnabledMocks) {
@@ -302,6 +329,14 @@ func SetupKeystoneMock(t *testing.T, userID, projectName string, enabled Enabled
 			th.TestMethod(t, r, "POST")
 
 			w.WriteHeader(http.StatusNoContent)
+		})
+	}
+
+	if enabled.UserGet {
+		th.Mux.HandleFunc(fmt.Sprintf("/v3/users/%s", userID), func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+
+			handleGetUser(t, w, r, userID)
 		})
 	}
 

--- a/openstack/path_static_creds.go
+++ b/openstack/path_static_creds.go
@@ -125,7 +125,7 @@ func (b *backend) pathStaticCredsRead(ctx context.Context, r *logical.Request, d
 	case SecretPassword:
 		authResponse := &authStaticResponseData{
 			AuthURL:  cloudConfig.AuthURL,
-			Username: role.Username,
+			Username: user.Name,
 			Password: role.Secret,
 			DomainID: user.DomainID,
 		}

--- a/openstack/path_static_creds.go
+++ b/openstack/path_static_creds.go
@@ -87,13 +87,18 @@ func (b *backend) pathStaticCredsRead(ctx context.Context, r *logical.Request, d
 		return nil, err
 	}
 
+	user, err := users.Get(client, role.UserID).Extract()
+	if err != nil {
+		return nil, err
+	}
+
 	var data map[string]interface{}
 	switch r := role.SecretType; r {
 	case SecretToken:
 		tokenOpts := &tokens.AuthOptions{
-			Username: role.Username,
+			Username: user.Name,
 			Password: role.Secret,
-			DomainID: role.DomainID,
+			DomainID: user.DomainID,
 			Scope:    getScopeFromStaticRole(role),
 		}
 
@@ -106,7 +111,7 @@ func (b *backend) pathStaticCredsRead(ctx context.Context, r *logical.Request, d
 			AuthURL:  cloudConfig.AuthURL,
 			Username: role.Username,
 			Token:    token.ID,
-			DomainID: role.DomainID,
+			DomainID: user.DomainID,
 		}
 
 		data = map[string]interface{}{
@@ -122,7 +127,7 @@ func (b *backend) pathStaticCredsRead(ctx context.Context, r *logical.Request, d
 			AuthURL:  cloudConfig.AuthURL,
 			Username: role.Username,
 			Password: role.Secret,
-			DomainID: role.DomainID,
+			DomainID: user.DomainID,
 		}
 		data = map[string]interface{}{
 			"auth": formStaticAuthResponse(

--- a/openstack/path_static_creds_test.go
+++ b/openstack/path_static_creds_test.go
@@ -30,6 +30,7 @@ func TestStaticCredentialsRead_ok(t *testing.T) {
 		TokenPost: true,
 		TokenGet:  true,
 		UserList:  true,
+		UserGet:   true,
 	})
 
 	testClient := thClient.ServiceClient()
@@ -49,7 +50,7 @@ func TestStaticCredentialsRead_ok(t *testing.T) {
 	t.Run("user_token", func(t *testing.T) {
 		require.NoError(t, s.Put(context.Background(), cloudEntry))
 
-		roleName := createSaveRandomStaticRole(t, s, projectName, "token", secret, "")
+		roleName := createSaveRandomStaticRole(t, s, projectName, "token", secret, userID)
 
 		res, err := b.HandleRequest(context.Background(), &logical.Request{
 			Operation: logical.ReadOperation,
@@ -62,7 +63,7 @@ func TestStaticCredentialsRead_ok(t *testing.T) {
 	t.Run("user_password", func(t *testing.T) {
 		require.NoError(t, s.Put(context.Background(), cloudEntry))
 
-		roleName := createSaveRandomStaticRole(t, s, projectName, "password", secret, "")
+		roleName := createSaveRandomStaticRole(t, s, projectName, "password", secret, userID)
 
 		res, err := b.HandleRequest(context.Background(), &logical.Request{
 			Operation: logical.ReadOperation,
@@ -159,6 +160,7 @@ func TestRotateStaticCredentials_ok(t *testing.T) {
 		TokenPost:      true,
 		TokenGet:       true,
 		PasswordChange: true,
+		UserGet:        true,
 	})
 
 	testClient := thClient.ServiceClient()


### PR DESCRIPTION
Fixed token creation when ``domain_name`` or ``domain_id`` is specified for static role.

Acceptance tests (failing on unrelated ``info`` test):
-----------------------------------------------------
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestInfo
    info_test.go:42: 
                Error Trace:    info_test.go:42
                Error:          Should NOT be empty, but was &{    }
                Test:           TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
    roles_test.go:53: Cloud with name `bcfmyuiyfy` was created
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== CONT  TestPlugin/TestRoleLifecycle
    plugin_test.go:337: Cloud with name `bcfmyuiyfy` has been removed
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `bifj` was created
    plugin_test.go:337: Cloud with name `bifj` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
=== RUN   TestPlugin/TestStaticCredsLifecycle
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_password
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_id
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_name
=== RUN   TestPlugin/TestStaticRoleLifecycle
=== RUN   TestPlugin/TestStaticRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestStaticRoleLifecycle/DeleteRole
--- FAIL: TestPlugin (28.77s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.09s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.08s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (6.36s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (1.95s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (2.24s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (1.08s)
    --- FAIL: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.01s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.01s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (5.86s)
    --- PASS: TestPlugin/TestStaticCredsLifecycle (13.18s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_password (3.75s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_id (4.23s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_name (3.95s)
    --- PASS: TestPlugin/TestStaticRoleLifecycle (3.09s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/WriteRole (1.05s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/DeleteRole (0.00s)
FAIL
FAIL    github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   29.343s
FAIL
make: *** [functional] Error 1
