### PR TITLE
Static roles: enable `username` change on PUT request

### DIFF
--- a/openstack/path_static_role.go
+++ b/openstack/path_static_role.go
@@ -255,7 +255,7 @@ func (b *backend) pathStaticRoleUpdate(ctx context.Context, req *logical.Request
 		entry = &roleStaticEntry{Name: name, Cloud: cloudName}
 	}
 
-	if username, ok := d.GetOk("username"); ok && req.Operation == logical.CreateOperation {
+	if username, ok := d.GetOk("username"); ok {
 		entry.Username = username.(string)
 		password, err := Passwords{}.Generate(ctx)
 		if err != nil {


### PR DESCRIPTION
Fix an issue when PUT request wouldn't change username for static role.
Refers to: #124 

### Acceptance tests
$ vault-plugin-secrets-openstack % make functional
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestCredsLifecycle/user_domain_id_token
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestInfo
    info_test.go:42: 
                Error Trace:    info_test.go:42
                Error:          Should NOT be empty, but was &{    }
                Test:           TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `ki24` was created
    plugin_test.go:337: Cloud with name `ki24` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
=== RUN   TestPlugin/TestStaticCredsLifecycle
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_password
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_id
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_name
=== RUN   TestPlugin/TestStaticRoleLifecycle
=== RUN   TestPlugin/TestStaticRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestStaticRoleLifecycle/DeleteRole
--- FAIL: TestPlugin (29.45s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.05s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.05s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (8.27s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (1.94s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_domain_id_token (2.13s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (0.86s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (2.41s)
    --- FAIL: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.59s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.58s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (5.00s)
    --- PASS: TestPlugin/TestStaticCredsLifecycle (12.67s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_password (3.31s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_id (4.02s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_name (4.06s)
    --- PASS: TestPlugin/TestStaticRoleLifecycle (2.74s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/WriteRole (1.02s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/DeleteRole (0.00s)
FAIL
FAIL    github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   29.924s
FAIL
make: *** [functional] Error 1
