### PR TITLE
Static roles: detailed openstack domain/project settings + error messages fix

### DIFF
--- a/acceptance/creds_test.go
+++ b/acceptance/creds_test.go
@@ -6,7 +6,6 @@ package acceptance
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/opentelekomcloud/vault-plugin-secrets-openstack/openstack"
@@ -31,7 +30,6 @@ type testCase struct {
 func (p *PluginTest) TestCredsLifecycle() {
 	t := p.T()
 
-	userDomainID := os.Getenv("USER_DOMAIN_ID")
 	cloud := openstackCloudConfig(t)
 	require.NotEmpty(t, cloud)
 
@@ -68,7 +66,7 @@ func (p *PluginTest) TestCredsLifecycle() {
 		"user_domain_id_token": {
 			Cloud:        cloud.Name,
 			ProjectID:    aux.ProjectID,
-			UserDomainID: userDomainID,
+			UserDomainID: aux.DomainID,
 			Root:         false,
 			SecretType:   "token",
 			UserRoles:    []string{"member"},

--- a/acceptance/static_creds_test.go
+++ b/acceptance/static_creds_test.go
@@ -16,13 +16,14 @@ import (
 )
 
 type testStaticCase struct {
-	cloud       string
-	projectID   string
-	projectName string
-	domainID    string
-	secretType  string
-	username    string
-	extensions  map[string]interface{}
+	cloud        string
+	projectID    string
+	projectName  string
+	domainID     string
+	secretType   string
+	username     string
+	userDomainId string
+	extensions   map[string]interface{}
 }
 
 func (p *PluginTest) TestStaticCredsLifecycle() {
@@ -66,6 +67,16 @@ func (p *PluginTest) TestStaticCredsLifecycle() {
 			domainID:    aux.DomainID,
 			username:    "static-test-3",
 			secretType:  "token",
+			extensions: map[string]interface{}{
+				"identity_api_version": "3",
+			},
+		},
+		"user_domain_id_token": {
+			cloud:        cloud.Name,
+			projectID:    aux.ProjectID,
+			username:     "static-test-4",
+			userDomainId: aux.DomainID,
+			secretType:   "token",
 			extensions: map[string]interface{}{
 				"identity_api_version": "3",
 			},
@@ -152,13 +163,14 @@ func staticRotateCredsURL(roleName string) string {
 
 func cloudToStaticRoleMap(data testStaticCase) map[string]interface{} {
 	return fixtures.SanitizedMap(map[string]interface{}{
-		"cloud":        data.cloud,
-		"project_id":   data.projectID,
-		"project_name": data.projectName,
-		"domain_id":    data.domainID,
-		"secret_type":  data.secretType,
-		"username":     data.username,
-		"extensions":   data.extensions,
+		"cloud":          data.cloud,
+		"project_id":     data.projectID,
+		"project_name":   data.projectName,
+		"user_domain_id": data.userDomainId,
+		"domain_id":      data.domainID,
+		"secret_type":    data.secretType,
+		"username":       data.username,
+		"extensions":     data.extensions,
 	})
 }
 

--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -182,10 +182,10 @@ created. If the role exists, it will be updated with the new attributes.
   `domain_id`.
 
 - `user_domain_id` `(string: <optional>)` - Specifies domain where user will be created with given domain id. 
-  Mutually exclusive with `user_project_name`.
+  Mutually exclusive with `user_domain_name`.
 
 - `user_domain_name` `(string: <optional>)` - Specifies domain where user will be created with given domain name.
-  Mutually exclusive with `user_project_id`.
+  Mutually exclusive with `user_domain_id`.
 
 - `project_domain_id` `(string: <optional>)` - Specifies domain for project-scoped role with given domain id.
   If one of `project_id` / `project_name` is not set `project_domain_id` value is ignored.
@@ -472,7 +472,19 @@ created. If the role exists, it will be updated with the new attributes.
 - `domain_name` `(string: <optional>)` - Create a domain-scoped role with given domain name. Mutually exclusive with
   `domain_id`.
 
-When none of `project_name` or `project_id` is set, created role will have a project scope.
+- `user_domain_id` `(string: <optional>)` - Specifies domain id of existing user.
+  Mutually exclusive with `user_domain_name`.
+
+- `user_domain_name` `(string: <optional>)` - Specifies domain name of existing user.
+  Mutually exclusive with `user_domain_id`.
+
+- `project_domain_id` `(string: <optional>)` - Specifies domain for project-scoped role with given domain id.
+  If one of `project_id` / `project_name` is not set `project_domain_id` value is ignored.
+
+- `project_domain_name` `(string: <optional>)` - Specifies domain for project-scoped role with given domain name.
+  If one of `project_id` / `project_name` is not set `project_domain_name` value is ignored.
+
+When one of `project_name` or `project_id` is set, created static role will have a project scope.
 
 - `extensions` `(list: [])` - A list of strings representing a key/value pair to be used as extensions to the cloud
   configuration (e.g. `volume_api_version` or endpoint overrides). Format is a key and value

--- a/openstack/path_cloud.go
+++ b/openstack/path_cloud.go
@@ -174,7 +174,7 @@ func (b *backend) pathCloudCreateUpdate(ctx context.Context, r *logical.Request,
 		// validate template first
 		_, err := RandomTemporaryUsername(cloudConfig.UsernameTemplate, &roleEntry{})
 		if err != nil {
-			return logical.ErrorResponse("invalid username template: %s", err), nil
+			return logical.ErrorResponse("invalid username template: %w", err), nil
 		}
 	} else if r.Operation == logical.CreateOperation {
 		cloudConfig.UsernameTemplate = DefaultUsernameTemplate

--- a/openstack/path_static_creds.go
+++ b/openstack/path_static_creds.go
@@ -196,6 +196,12 @@ func getScopeFromStaticRole(role *roleStaticEntry) tokens.Scope {
 		scope = tokens.Scope{
 			ProjectID: role.ProjectID,
 		}
+	case role.ProjectName != "" && (role.ProjectDomainName != "" || role.ProjectDomainID != ""):
+		scope = tokens.Scope{
+			ProjectName: role.ProjectName,
+			DomainName:  role.ProjectDomainName,
+			DomainID:    role.ProjectDomainID,
+		}
 	case role.ProjectName != "":
 		scope = tokens.Scope{
 			ProjectName: role.ProjectName,

--- a/openstack/path_static_role_test.go
+++ b/openstack/path_static_role_test.go
@@ -37,15 +37,19 @@ func expectedStaticRoleData(cloudName string) (*roleStaticEntry, map[string]inte
 		DomainName:       tools.RandomString("d", 5),
 	}
 	expectedMap := map[string]interface{}{
-		"cloud":             expected.Cloud,
-		"project_id":        "",
-		"project_name":      expected.ProjectName,
-		"domain_id":         "",
-		"domain_name":       expected.DomainName,
-		"extensions":        map[string]string{},
-		"rotation_duration": expTTL,
-		"secret_type":       "token",
-		"username":          "static-test",
+		"cloud":               expected.Cloud,
+		"project_id":          "",
+		"project_name":        expected.ProjectName,
+		"domain_id":           "",
+		"domain_name":         expected.DomainName,
+		"project_domain_id":   "",
+		"project_domain_name": "",
+		"user_domain_id":      "",
+		"user_domain_name":    "",
+		"extensions":          map[string]string{},
+		"rotation_duration":   expTTL,
+		"secret_type":         "token",
+		"username":            "static-test",
 	}
 	return expected, expectedMap
 }


### PR DESCRIPTION
Added `user_domain_id/name` and `project_domain_id/name` parameters for detailed static roles management.
Several error messages fixed.

### Acceptance tests
vault-plugin-secrets-openstack % make functional
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/user_domain_id_token
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestInfo
    info_test.go:42: 
                Error Trace:    info_test.go:42
                Error:          Should NOT be empty, but was &{    }
                Test:           TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `4bju` was created
    plugin_test.go:337: Cloud with name `4bju` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
=== RUN   TestPlugin/TestStaticCredsLifecycle
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_password
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_id
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_name
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_domain_id_token
=== RUN   TestPlugin/TestStaticRoleLifecycle
=== RUN   TestPlugin/TestStaticRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestStaticRoleLifecycle/DeleteRole
--- FAIL: TestPlugin (32.71s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.04s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.04s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (7.99s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_domain_id_token (2.96s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (0.83s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (2.38s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (0.97s)
    --- FAIL: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.61s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.59s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (4.72s)
    --- PASS: TestPlugin/TestStaticCredsLifecycle (16.24s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_password (3.38s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_id (4.00s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_name (3.91s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_domain_id_token (3.92s)
    --- PASS: TestPlugin/TestStaticRoleLifecycle (2.96s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/WriteRole (1.05s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/DeleteRole (0.00s)
FAIL
FAIL    github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   33.138s
FAIL
make: *** [functional] Error 1
