### PR TITLE
Path_Clouds: add rotation parameters for future auto rotate root implementation

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -22,6 +22,8 @@ will overwrite them.
 
 * `password` `(string: <required>)` - OpenStack password of the root user.
 
+* `root_password_ttl` `(string: <optional>)` - Password rotation period. Default period is six month.
+
 * `username_template` `(string: "vault{{random 8 | lowercase}}")` - Template used for usernames
   of temporary users. For details on templating syntax please refer to
   [Username Templating](https://www.vaultproject.io/docs/concepts/username-templating). Additional
@@ -39,7 +41,8 @@ will overwrite them.
   "username": "admin",
   "password": "RcigTiYrJjVmEkrV71Cd",
   "user_domain_name": "Default",
-  "username_template": "user-{{ .RoleName }}-{{ random 4 }}"
+  "username_template": "user-{{ .RoleName }}-{{ random 4 }}",
+  "root_password_ttl": "5h"
 }
 ```
 

--- a/openstack/backend.go
+++ b/openstack/backend.go
@@ -147,13 +147,3 @@ func (c *sharedCloud) initClient(ctx context.Context, s logical.Storage) error {
 
 	return nil
 }
-
-type OsCloud struct {
-	Name             string `json:"name"`
-	AuthURL          string `json:"auth_url"`
-	UserDomainName   string `json:"user_domain_name"`
-	Username         string `json:"username"`
-	Password         string `json:"password"`
-	UsernameTemplate string `json:"username_template"`
-	PasswordPolicy   string `json:"password_policy"`
-}


### PR DESCRIPTION
Path clouds is updated with additional parameters for auto rotate root with periodicfunc.

### Acceptance tests
vault-plugin-secrets-openstack % make functional
Running acceptance tests...
=== RUN   TestPlugin
=== RUN   TestPlugin/TestCloudLifecycle
=== RUN   TestPlugin/TestCloudLifecycle/WriteCloud
=== RUN   TestPlugin/TestCloudLifecycle/ReadCloud
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== RUN   TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== PAUSE TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-LIST
=== CONT  TestPlugin/TestCloudLifecycle/ListClouds/method-GET
=== RUN   TestPlugin/TestCloudLifecycle/DeleteCloud
=== RUN   TestPlugin/TestCredsLifecycle
=== RUN   TestPlugin/TestCredsLifecycle/user_domain_id_token
=== RUN   TestPlugin/TestCredsLifecycle/root_token
=== RUN   TestPlugin/TestCredsLifecycle/user_token
=== RUN   TestPlugin/TestCredsLifecycle/user_password
=== RUN   TestPlugin/TestInfo
    info_test.go:42: 
                Error Trace:    info_test.go:42
                Error:          Should NOT be empty, but was &{    }
                Test:           TestPlugin/TestInfo
=== RUN   TestPlugin/TestRoleLifecycle
=== RUN   TestPlugin/TestRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestRoleLifecycle/DeleteRole
=== RUN   TestPlugin/TestRootRotate
    rotate_test.go:65: Cloud with name `default1` was created
    rotate_test.go:68: Cloud with name `ixqy` was created
    plugin_test.go:337: Cloud with name `ixqy` has been removed
    plugin_test.go:337: Cloud with name `default1` has been removed
=== RUN   TestPlugin/TestStaticCredsLifecycle
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_password
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_id
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_token_project_name
=== RUN   TestPlugin/TestStaticCredsLifecycle/user_domain_id_token
=== RUN   TestPlugin/TestStaticRoleLifecycle
=== RUN   TestPlugin/TestStaticRoleLifecycle/WriteRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ReadRole
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== RUN   TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== PAUSE TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST
=== CONT  TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET
=== RUN   TestPlugin/TestStaticRoleLifecycle/DeleteRole
--- FAIL: TestPlugin (32.04s)
    --- PASS: TestPlugin/TestCloudLifecycle (0.05s)
        --- PASS: TestPlugin/TestCloudLifecycle/WriteCloud (0.05s)
        --- PASS: TestPlugin/TestCloudLifecycle/ReadCloud (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/ListClouds (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-LIST (0.00s)
            --- PASS: TestPlugin/TestCloudLifecycle/ListClouds/method-GET (0.00s)
        --- PASS: TestPlugin/TestCloudLifecycle/DeleteCloud (0.00s)
    --- PASS: TestPlugin/TestCredsLifecycle (8.18s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_domain_id_token (3.05s)
        --- PASS: TestPlugin/TestCredsLifecycle/root_token (0.83s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_token (2.44s)
        --- PASS: TestPlugin/TestCredsLifecycle/user_password (1.03s)
    --- FAIL: TestPlugin/TestInfo (0.00s)
    --- PASS: TestPlugin/TestRoleLifecycle (0.61s)
        --- PASS: TestPlugin/TestRoleLifecycle/WriteRole (0.60s)
        --- PASS: TestPlugin/TestRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-LIST (0.00s)
            --- PASS: TestPlugin/TestRoleLifecycle/ListRoles/method-GET (0.00s)
        --- PASS: TestPlugin/TestRoleLifecycle/DeleteRole (0.00s)
    --- PASS: TestPlugin/TestRootRotate (4.69s)
    --- PASS: TestPlugin/TestStaticCredsLifecycle (15.61s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_password (3.26s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_id (3.83s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_token_project_name (3.76s)
        --- PASS: TestPlugin/TestStaticCredsLifecycle/user_domain_id_token (3.70s)
    --- PASS: TestPlugin/TestStaticRoleLifecycle (2.78s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/WriteRole (1.03s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ReadRole (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-GET (0.00s)
            --- PASS: TestPlugin/TestStaticRoleLifecycle/ListRoles/method-LIST (0.00s)
        --- PASS: TestPlugin/TestStaticRoleLifecycle/DeleteRole (0.00s)
FAIL
FAIL    github.com/opentelekomcloud/vault-plugin-secrets-openstack/acceptance   32.382s
FAIL
make: *** [functional] Error 1
